### PR TITLE
Restrict site build to main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Build and deploy with Nikola
-on: [push]
+on: 
+  push:
+    branches:
+      - main
 
 jobs:
   nikola_build:


### PR DESCRIPTION
I'm getting annoying build fails while I work in branches, I think this should stop it ;)