### PR TITLE
Remove ansible.com stylesheet

### DIFF
--- a/themes/ansible-community/sass/_clipboard.scss
+++ b/themes/ansible-community/sass/_clipboard.scss
@@ -1,31 +1,32 @@
 .clipboard {
-	font-size: large;
-	font-family: $redhat-display;
-	text-align: left;
-	pre {
-		background-color: $pool;
-		color: $black;
-		display: inline-block;
-		padding-top: 20px;
-		padding-left: 10px;
-		padding-bottom: 0px;
-		position: relative;
-		width: 100%;
-		text-align: left;
-	}
-	code {
-		background: none;
-	}
-	.btn {
-		background-color: transparent;
-		border: 0px;
-		position: absolute;
-		top: 10px;
-		right: 0px;
-		cursor: pointer;
-	}
-	.fa-copy {
-        color: $black;
-        background-color: transparent;
-	}
+  font-size: large;
+  font-family: $redhat-display;
+  text-align: left;
+  pre {
+    background-color: $pool;
+    color: $black;
+    display: inline-block;
+    padding-top: 20px;
+    padding-left: 10px;
+    padding-bottom: 0px;
+    position: relative;
+    width: 100%;
+    text-align: left;
+  }
+  code {
+    background: none;
+  }
+  .btn {
+    background-color: transparent;
+    border: 0px;
+    position: absolute;
+    top: 10px;
+    right: 0px;
+    cursor: pointer;
+    padding: 0.625rem 2rem;
+  }
+  .fa-copy {
+    color: $black;
+    background-color: transparent;
+  }
 }

--- a/themes/ansible-community/sass/_homepage-platform-band.scss
+++ b/themes/ansible-community/sass/_homepage-platform-band.scss
@@ -1,16 +1,18 @@
 .homepage-platform-band {
-    padding-bottom: 2rem;
-    margin: 6rem auto;
-    text-align: left;
+  padding-bottom: 2rem;
+  margin: 6rem auto;
+  text-align: left;
 }
 
 .learn-more {
-    a {
-        background-color: $red-hat-red;
-        color: $white;
-        &:hover {
-          background-color: $red-hat-red;
-          color: $black;
-        }
+  a {
+    background-color: $red-hat-red;
+    color: $white;
+    font-weight: 700;
+    padding: 0.625rem 2rem;
+    &:hover {
+      background-color: $red-hat-red;
+      color: $black;
     }
+  }
 }

--- a/themes/ansible-community/sass/_nav-bar.scss
+++ b/themes/ansible-community/sass/_nav-bar.scss
@@ -1,0 +1,28 @@
+.navbar-padding {
+  padding: 0;
+}
+
+.nav-link-color {
+  color: $white !important;
+  &:hover {
+    color: $light-grey !important;
+  }
+}
+
+.nav-toggle-icon {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") !important;
+}
+
+.dropdown-menu-border {
+  border: 0 solid rgba(0,0,0,.15);
+  border-radius: 3px;
+  a:active {
+    background-color: $red-hat-red !important;
+  }
+}
+
+.active {
+  color: $white !important;
+  text-decoration: none !important;
+  background-color: $red-hat-red !important;
+}

--- a/themes/ansible-community/sass/main.scss
+++ b/themes/ansible-community/sass/main.scss
@@ -2,6 +2,7 @@
 @import "fonts";
 @import "clipboard";
 @import "grid-wrapper";
+@import "nav-bar";
 @import "homepage-ansible-band";
 @import "homepage-feature-band";
 @import "homepage-bullhorn-band";

--- a/themes/ansible-community/templates/base.tmpl
+++ b/themes/ansible-community/templates/base.tmpl
@@ -14,7 +14,7 @@
 
 <!-- Menubar -->
 
-<nav class="navbar navbar-expand-md static-top mb-4
+<nav class="navbar navbar-expand-md static-top mb-4 navbar-padding
 {% if theme_config.get('navbar_light') %}
 navbar-light
 {% else %}
@@ -39,7 +39,7 @@ bg-dark
         {% endif %}
         </a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#bs-navbar" aria-controls="bs-navbar" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
+            <span class="navbar-toggler-icon nav-toggle-icon"></span>
         </button>
 
         <div class="collapse navbar-collapse" id="bs-navbar">

--- a/themes/ansible-community/templates/base_helper.tmpl
+++ b/themes/ansible-community/templates/base_helper.tmpl
@@ -143,8 +143,8 @@ lang="{{ lang }}">
 {% macro html_navigation_links_entries(navigation_links_source) %}
     {% for url, text in navigation_links_source[lang] %}
         {% if isinstance(url, tuple) %}
-            <li class="nav-item dropdown"><a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ text }}</a>
-            <div class="dropdown-menu">
+            <li class="nav-item dropdown"><a href="#" class="nav-link nav-link-color dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ text }}</a>
+            <div class="dropdown-menu dropdown-menu-border">
             {% for suburl, text in url %}
                 {% if rel_link(permalink, suburl) == "#" %}
                     <a href="{{ permalink }}" class="dropdown-item active">{{ text }} <span class="sr-only">{{ messages("(active)", lang) }}</span></a>
@@ -155,9 +155,9 @@ lang="{{ lang }}">
             </div>
         {% else %}
             {% if rel_link(permalink, url) == "#" %}
-                <li class="nav-item active"><a href="{{ permalink }}" class="nav-link">{{ text }} <span class="sr-only">{{ messages("(active)", lang) }}</span></a>
+                <li class="nav-item active"><a href="{{ permalink }}" class="nav-link nav-link-color">{{ text }} <span class="sr-only">{{ messages("(active)", lang) }}</span></a>
             {% else %}
-                <li class="nav-item"><a href="{{ url }}" class="nav-link">{{ text }}</a>
+                <li class="nav-item"><a href="{{ url }}" class="nav-link nav-link-color">{{ text }}</a>
             {% endif %}
         {% endif %}
     {% endfor %}
@@ -170,7 +170,7 @@ lang="{{ lang }}">
 {% macro html_translations() %}
     {% for langname in translations|sort %}
         {% if langname != lang %}
-            <li class="nav-item"><a href="{{ _link("root", None, langname) }}" rel="alternate" hreflang="{{ langname }}" class="nav-link">{{ messages("LANGUAGE", langname) }}</a></li>
+            <li class="nav-item"><a href="{{ _link("root", None, langname) }}" rel="alternate" hreflang="{{ langname }}" class="nav-link nav-link-color">{{ messages("LANGUAGE", langname) }}</a></li>
         {% endif %}
     {% endfor %}
 {% endmacro %}

--- a/themes/ansible-community/templates/base_helper.tmpl
+++ b/themes/ansible-community/templates/base_helper.tmpl
@@ -123,9 +123,6 @@ lang="{{ lang }}">
             href="https://use.fontawesome.com/releases/v5.1.0/css/all.css"
             integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt"
             crossorigin="anonymous"/>
-        <!-- Ansible.com css -->
-        <link rel="stylesheet"
-            href="https://www.ansible.com/hubfs/css/styles.min.css"/>
         <!-- Sass compiled css  -->
         <link rel="stylesheet" href="/assets/css/main.css">
         <link rel="stylesheet" href="/assets/css/redhat-footer.css">

--- a/themes/ansible-community/templates/homepage-ansible-band.tmpl
+++ b/themes/ansible-community/templates/homepage-ansible-band.tmpl
@@ -6,7 +6,7 @@
   <div class="width-5-12 width-12-12-m">
     <h3>{{ homepage.version }}</h3>
     <div class="clipboard">
-      <pre><code id="clip">{{ homepage.install }}</code><button class="btn" data-clipboard-action="copy" data-clipboard-target="#clip">
+      <pre><code id="clip">{{ homepage.install }}</code><button class="btn text-nowrap" data-clipboard-action="copy" data-clipboard-target="#clip">
         <i class="fa fa-copy" aria-hidden="true"></i></button>
       </pre>
     </div>


### PR DESCRIPTION
Addresses https://github.com/ansible-community/community-website/issues/45

- Removes the ansible.com stylesheet
- Addresses styling issue (vertical scrollbar) for the clipboard button for the installation code snippet
- Addresses styling for the "Learn more about Ansible Automation Platform" button

#### Please note:
The navigation bar looks different. The bootstrap version has the navigation bar appear a bit taller and the navigation links have a slightly darker color leading to reduced contrast with the navigation background. IMO the contrast could be improved but since this styling appears to be standard on bootstrap pages I'd like to hear more thoughts. 

With styles from the ansible.com stylesheet:
<img width="1445" alt="image" src="https://user-images.githubusercontent.com/43621546/234080543-292af753-e3ca-405b-bf8b-3249e485b296.png">

Without styles from the ansible.com stylesheet:
<img width="1444" alt="image" src="https://user-images.githubusercontent.com/43621546/234080593-b87421cb-72d4-48bf-8054-e2b4e1f09f03.png">
