### PR TITLE
Support FontAwesome icons in the nav

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -152,17 +152,17 @@ NAVIGATION_ALT_LINKS = {
     DEFAULT_LANG: (
         (
           (
-            ("/blog/", "Latest Posts"),
-            ("/categories/", "Tags"),
-            ("/blog/archive.html", "Post Archive"),
-            ("/rss.xml", "RSS feed"),
+            ("/blog/", "Latest Posts", "fa fa-comment"),
+            ("/categories/", "Tags", "fa fa-tag"),
+            ("/blog/archive.html", "Post Archive", ""),
+            ("/rss.xml", "RSS feed", "fa fa-rss-square"),
           ),
-          "Blog"
+          "Blog", "fa fa-comment"
         ),
-        ("/events/", "Events"),
-        ("https://fosstodon.org/@ansible", "Fosstodon"),
-        ("https://forum.ansible.com/", "Discourse"),
-        ("https://github.com/ansible-community", "GitHub"),
+        ("/events/", "Events", "fa fa-calendar"),
+        ("https://fosstodon.org/@ansible", "Fosstodon", "fab fa-mastodon"),
+        ("https://forum.ansible.com/", "Discourse", "fab fa-discourse"),
+        ("https://github.com/ansible-community", "GitHub", "fab fa-github"),
     )
 }
 

--- a/themes/ansible-community/templates/base_helper.tmpl
+++ b/themes/ansible-community/templates/base_helper.tmpl
@@ -141,25 +141,45 @@ lang="{{ lang }}">
 {% endmacro %}
 
 {% macro html_navigation_links_entries(navigation_links_source) %}
-    {% for url, text in navigation_links_source[lang] %}
+    {% for url, text, icon in navigation_links_source[lang] %}
         {% if isinstance(url, tuple) %}
-            <li class="nav-item dropdown"><a href="#" class="nav-link nav-link-color dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ text }}</a>
-            <div class="dropdown-menu dropdown-menu-border">
-            {% for suburl, text in url %}
+            <li class="nav-item dropdown">
+	        <a href="#" class="nav-link nav-link-color dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+		    <i class="{{ icon }}"></i> {{ text }}
+                </a>
+		<div class="dropdown-menu dropdown-menu-border">
+	    </li>
+            {% for suburl, text, icon in url %}
                 {% if rel_link(permalink, suburl) == "#" %}
-                    <a href="{{ permalink }}" class="dropdown-item active">{{ text }} <span class="sr-only">{{ messages("(active)", lang) }}</span></a>
+                    <a href="{{ permalink }}" class="dropdown-item active">
+		        <i class="{{ icon }}"></i> {{ text }} <span class="sr-only">{{ messages("(active)", lang) }}</span>
+                    </a>
                 {% else %}
-                    <a href="{{ suburl }}" class="dropdown-item">{{ text }}</a>
+                    <a href="{{ suburl }}" class="dropdown-item">
+		        <i class="{{ icon }}"></i> {{ text }}
+                    </a>
                 {% endif %}
             {% endfor %}
             </div>
         {% else %}
              {% if rel_link(permalink, url) == "#" %}
-                 <li class="nav-item active"><a href="{{ permalink }}" class="nav-link nav-link-color">{{ text }} <span class="sr-only">{{ messages("(active)", lang) }}</span></a>
+                 <li class="nav-item active">
+		     <a href="{{ permalink }}" class="nav-link nav-link-color">
+                         <i class="{{ icon }}"> {{ text }} <span class="sr-only">{{ messages("(active)", lang) }}</span>
+                     </a>
+                 </li>
              {% elif url.startswith("https://")  %}
-                 <li class="nav-item"><a href="{{ url }}" target="_blank" class="nav-link nav-link-color">{{ text }}</a>
+                 <li class="nav-item">
+		     <a href="{{ url }}" target="_blank" class="nav-link nav-link-color">
+		         <i class="{{ icon }}"></i> {{ text }}
+		     </a>
+		 </li>
              {% else %}
-                 <li class="nav-item"><a href="{{ url }}" class="nav-link nav-link-color">{{ text }}</a>
+                 <li class="nav-item">
+                     <a href="{{ url }}" class="nav-link nav-link-color">
+                         <i class="{{ icon }}"></i> {{ text }}
+                     </a>
+                 </li>
              {% endif %}
          {% endif %}
     {% endfor %}


### PR DESCRIPTION
I recall a discussion about extending the tuples in `conf.py` to support icon class codes, so I added it.

You can preview it on my fork: https://gregsutcliffe.github.io/ansible-community-website/

@vidyanambiar I've messed up something small here, if you look at https://gregsutcliffe.github.io/ansible-community-website/events you can see the nav item gets put into bold somehow - what did I break? :stuck_out_tongue: 