### PR TITLE
Add PR preview builds to GitHub Pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,8 @@
 name: Build and deploy with Nikola
-on: 
+on:
   push:
-    branches: main
-  pull_request:
-    branches: main
+    branches:
+    - main
 
 permissions:
   contents: write
@@ -13,19 +12,21 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Build and deploy website to gh-pages'
     steps:
+
     - name: Check out
       uses: actions/checkout@v3
+
     - name: Change sass binary in conf.py
       run: sed -i "s|SASS_COMPILER = 'sass'|SASS_COMPILER = 'sassc'|g" conf.py
-    - name: Test site build (via Nikola action)
-      if: ${{ github.event_name == 'pull_request' }}
+
+    - name: Build the site with Nikola
       uses: getnikola/nikola-action@v8
       with:
         dry_run: true
         apt_install: sassc
-    - name: Deploy site (via Nikola action)
-      if: ${{ github.event_name != 'pull_request' }}
-      uses: getnikola/nikola-action@v8
+
+    - name: Deploy to gh-pages 🚀
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
-        dry_run: false
-        apt_install: sassc
+        folder: ./output/
+        clean-exclude: previews/

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,36 @@
+name: Deploy PR previews
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    name: 'Deploy PR preview to gh-pages'
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Change sass binary in conf.py
+      run: sed -i "s|SASS_COMPILER = 'sass'|SASS_COMPILER = 'sassc'|g" conf.py
+
+    - name: Build the site with Nikola
+      uses: getnikola/nikola-action@v8
+      with:
+        dry_run: true
+        apt_install: sassc
+
+    - name: Deploy preview
+      uses: rossjrw/pr-preview-action@v1
+      with:
+        source-dir: ./output/
+        umbrella-dir: previews/
+        custom-url: ansible-community.github.io/community-website/


### PR DESCRIPTION
Fixes #16

This PR:

- Uses the [JamesIves action](https://github.com/JamesIves/github-pages-deploy-action) to deploy to gh-pages instead of the Nikola action. This allows us to avoid overwriting the pr-previews branch.
- Uses the [deploy-pr-preview action](https://github.com/marketplace/actions/deploy-pr-preview) to create PR preview builds of the community site.