### PR TITLE
Fix styling on clicking "Events" in the navigation menu

### DIFF
--- a/themes/ansible-community/templates/base_helper.tmpl
+++ b/themes/ansible-community/templates/base_helper.tmpl
@@ -165,7 +165,7 @@ lang="{{ lang }}">
              {% if rel_link(permalink, url) == "#" %}
                  <li class="nav-item active">
 		     <a href="{{ permalink }}" class="nav-link nav-link-color">
-                         <i class="{{ icon }}"> {{ text }} <span class="sr-only">{{ messages("(active)", lang) }}</span>
+                         <i class="{{ icon }}"></i> {{ text }} <span class="sr-only">{{ messages("(active)", lang) }}</span>
                      </a>
                  </li>
              {% elif url.startswith("https://")  %}


### PR DESCRIPTION
This PR fixes the styling issue (incorrect font) seen on clicking "Events" in the navigation menu (https://github.com/ansible-community/community-website/pull/66#issuecomment-1531079695).  It turned out to be caused by a missing closing tag.

![image](https://user-images.githubusercontent.com/43621546/236844333-39608f9c-a306-46fb-9692-b995b75427dc.png)

Fixed:
![image](https://user-images.githubusercontent.com/43621546/236844667-221ce538-a684-4e91-a2ee-cd88e215d100.png)

