### PR TITLE
Update action for building / deploying

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,6 @@
 name: Build and deploy with Nikola
 on:
-  push:
-    branches:
-    - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -16,14 +14,15 @@ jobs:
     - name: Check out
       uses: actions/checkout@v3
 
-    - name: Change sass binary in conf.py
-      run: sed -i "s|SASS_COMPILER = 'sass'|SASS_COMPILER = 'sassc'|g" conf.py
+    - name: Install Python dependencies
+      uses: py-actions/py-dependency-install@v4
+      with:
+        path: ./requirements.txt
 
     - name: Build the site with Nikola
       uses: getnikola/nikola-action@v8
       with:
         dry_run: true
-        apt_install: sassc
 
     - name: Deploy to gh-pages 🚀
       uses: JamesIves/github-pages-deploy-action@v4

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the assets required to build the Ansible Community website. Welcome!
 
-See the WIP site at https://ansible-community.github.io/community-website/
+See the WIP site at https://ansible-community-website.readthedocs.io/en/latest/
 
 ## Contributing to the website
 


### PR DESCRIPTION
This PR updates the workflow to build / deploy to gh pages so that it runs on user dispatch and uses the requirements file. Also points to the RTD site in the readme.