### PR TITLE
use fa arrows instead of utf-8

### DIFF
--- a/data/homepage.yaml
+++ b/data/homepage.yaml
@@ -41,8 +41,8 @@ ecosystem:
       logo: /assets/images/logo-eda.svg
 labels:
   learn_more: Learn more
-  view_more: View more&nbsp;&rarr;
-  back_to_top: Back to top&nbsp;&uarr;
+  view_more: View more
+  back_to_top: Back to top
 links:
   platform:
     home: https://www.ansible.com/

--- a/templates/homepage-back-to-top.tmpl
+++ b/templates/homepage-back-to-top.tmpl
@@ -1,3 +1,3 @@
 <div class="back-to-top">
-  <a href="#top">{{ homepage.labels.back_to_top }}</a>
+  <a href="#top">{{ homepage.labels.back_to_top }}&nbsp;<i class="fa fa-arrow-up"></i></a>
 </div>

--- a/templates/homepage-ecosystem-band.tmpl
+++ b/templates/homepage-ecosystem-band.tmpl
@@ -5,7 +5,7 @@
         <img class="section-icon" src="/assets/images/communities.svg" />
         <h2>{{ homepage.ecosystem.title }}</h2>
         <div class="section-view-more">
-          <a href="{{ homepage.ecosystem.url }}">{{ homepage.labels.view_more }}</a>
+          <a href="{{ homepage.ecosystem.url }}">{{ homepage.labels.view_more }}&nbsp;<i class="fa fa-arrow-right"></i></a>
         </div>
       </div>
       <p>{{ homepage.ecosystem.intro }}</p>


### PR DESCRIPTION
Replaces the UTF 8 arrows in back to top and view more with nicer looking font awesome icons.