### PR TITLE
move the top anchor to the body tag

### DIFF
--- a/templates/homepage.tmpl
+++ b/templates/homepage.tmpl
@@ -1,7 +1,6 @@
 {% extends "base.tmpl" %}
 {% block content %}
   <div class="container">
-    <a id="top"></a>
     {% include 'homepage-ansible-band.tmpl' %}
     {% include 'homepage-ecosystem-band.tmpl' %}
     {% include 'homepage-bullhorn-band.tmpl' %}

--- a/themes/ansible-community/templates/base.tmpl
+++ b/themes/ansible-community/templates/base.tmpl
@@ -9,7 +9,7 @@
 {% endblock %}
 {{ template_hooks['extra_head']() }}
 </head>
-<body>
+<body id="top">
 <a href="#content" class="sr-only sr-only-focusable">{{ messages("Skip to main content") }}</a>
 
 <!-- Menubar -->


### PR DESCRIPTION
This PR moves the `#top` anchor so that "Back to Top" goes to the very start of the page and includes the menu bar.