### PR TITLE
Simplify the contribute:ways key in the datafile

### DIFF
--- a/data/homepage.yaml
+++ b/data/homepage.yaml
@@ -90,16 +90,11 @@ blog:
 contribute:
   title: Contribute
   ways:
-    meetup:
-      text: Organize meetups with other automation enthusiasts.
-    talk:
-      text: Give lighting talks.
-    workshop:
-      text: Host Ansible workshops.
-    code:
-      text: Code a new module or fix a bug.
-    docs:
-      text: Improve the documentation.
+    - Organize meetups with other automation enthusiasts.
+    - Give lighting talks.
+    - Host Ansible workshops.
+    - Code a new module or fix a bug.
+    - Improve the documentation.
   many: There are so many ways you can contribute to Ansible.
   talk: If you'd like to contribute to Ansible but aren't sure where to start, come and talk to us.
   link: https://forum.ansible.com/pub/how-to-contribute

--- a/templates/homepage-contribute-band.tmpl
+++ b/templates/homepage-contribute-band.tmpl
@@ -10,9 +10,9 @@
   <div class="contribute-content">
     <div class="contribute-row">
       <div class="contribute-box-left">
-        {% for key, item in homepage.contribute.ways.items() %}
+        {% for item in homepage.contribute.ways %}
         <ul>
-          <li><i class="fa fa-star" aria-hidden="true"></i>&nbsp;{{ item.text }}</li>
+          <li><i class="fa fa-star" aria-hidden="true"></i>&nbsp;{{ item }}</li>
         </ul>
         {% endfor %}
         <p>{{ homepage.contribute.many }}</p>


### PR DESCRIPTION
As per #105 comment, we can simplify this data structure. There's no need to name the keys, the names aren't used and we may want to specify others in the future.