### PR TITLE
Adds the tabbed menu from the wireframe

### DIFF
--- a/data/homepage.yaml
+++ b/data/homepage.yaml
@@ -5,6 +5,7 @@ banner:
   latest_version: Ansible 7 is now available.
   how_to_install: Install by copying the pip command.
 automate:
+  section_icon: /assets/images/automation.svg
   title: Why Ansible?
   intro: Working in IT, you're likely doing the same tasks over and over. What if you could solve problems once and then automate your solutions going forward? Ansible is here to help.
   top_section:
@@ -27,6 +28,7 @@ automate:
         It is easy to learn, beautiful code that reads like clear documentation.
         After all, automation should not be more complex than the tasks it replaces.
 community:
+  section_icon: /assets/images/community.svg
   title: Community
   ansible_community: >-
     Ansible is built on open source collaboration.
@@ -62,6 +64,7 @@ bullhorn:
   placeholder: Insert email address here
   button: Subscribe
 events:
+  section_icon: /assets/images/calendar.svg
   title: Events
   intro: Join Ansible events, in person or online, to share and learn about automation.
   url: https://forum.ansible.com/c/events/
@@ -82,10 +85,12 @@ events:
       image: contributor-summit-durham-2023.png
       link: https://forum.ansible.com/t/ansible-contributor-summit-durham-2023/28
 platform:
+  section_icon: /images/platform.svg
   main: Get enterprise engineering and support from Red Hat with a platform that can tackle any automation challenge.
   discover: Red Hat Ansible Automation Platform provides everything needed to create, execute, and manage automation in a single subscription. From execution environments to certified collections to automation analytics, discover the features and benefits of Ansible Automation Platform.
   learn: Learn more about Red Hat Ansible Automation Platform
 ecosystem:
+  section_icon: /assets/images/communities.svg
   title: Ecosystem
   intro: Projects in the Ansible ecosystem let you expand automation to a virtually unlimited set of use cases.
   url: https://docs.ansible.com/ecosystem.html
@@ -112,10 +117,12 @@ ecosystem:
       link: https://ansible.readthedocs.io/projects/rulebook/
       logo: logo-eda.svg
 blog:
+  section_icon: /assets/images/blog.svg
   title: Blogs
   intro: Read all about it!
   url: /blog/
 contribute:
+  section_icon: /assets/images/collaboration.svg
   title: Contribute
   heading: You can contribute to Ansible in so many ways...
   ways:
@@ -139,3 +146,4 @@ links:
     get_started_url: https://docs.ansible.com/ansible/latest/getting_started/index.html
   platform:
     home: https://www.redhat.com/en/technologies/management/ansible
+

--- a/templates/homepage-automate-band.tmpl
+++ b/templates/homepage-automate-band.tmpl
@@ -1,8 +1,8 @@
-<div class="grid-wrapper homepage-automate-band">
+<div class="grid-wrapper homepage-automate-band" id="automate">
   <div class="width-12-12 width-12-12-m">
     <div class="section-title">
       <div class="section-top">
-        <img class="section-icon" src="/assets/images/automation.svg" />
+        <img class="section-icon" src="{{ homepage.automate.section_icon }}" />
         <h2>{{ homepage.automate.title }}</h2>
       </div>
       <p>{{ homepage.automate.intro }}</p>

--- a/templates/homepage-blog-band.tmpl
+++ b/templates/homepage-blog-band.tmpl
@@ -1,8 +1,8 @@
-<div class="grid-wrapper homepage-blog-band">
+<div class="grid-wrapper homepage-blog-band" id="blog">
   <div class="width-12-12 width-12-12-m">
     <div class="section-title">
       <div class="section-top">
-        <img class="section-icon" src="/assets/images/blog.svg" />
+        <img class="section-icon" src="{{ homepage.blog.section_icon }}" />
         <h2>{{ homepage.blog.title }}</h2>
         <div class="section-view-more">
           <a href="{{ homepage.blog.url }}">{{ homepage.labels.view_more }}&nbsp;<i class="fa fa-arrow-right"></i></a>

--- a/templates/homepage-community-band.tmpl
+++ b/templates/homepage-community-band.tmpl
@@ -1,8 +1,8 @@
-<div class="grid-wrapper homepage-community-band">
+<div class="grid-wrapper homepage-community-band" id="community">
   <div class="width-12-12 width-12-12-m">
     <div class="section-title">
       <div class="section-top">
-        <img class="section-icon" src="/assets/images/community.svg" />
+        <img class="section-icon" src="{{ homepage.community.section_icon }}" />
         <h2>{{ homepage.community.title }}</h2>
       </div>
     </div>

--- a/templates/homepage-contribute-band.tmpl
+++ b/templates/homepage-contribute-band.tmpl
@@ -1,8 +1,8 @@
-<div class="grid-wrapper homepage-contribute-band">
+<div class="grid-wrapper homepage-contribute-band" id="contribute">
   <div class="width-12-12 width-12-12-m">
     <div class="section-title">
       <div class="section-top">
-        <img class="section-icon" src="/assets/images/collaboration.svg" />
+        <img class="section-icon" src="{{ homepage.contribute.section_icon }}" />
         <h2>{{ homepage.contribute.title }}</h2>
       </div>
     </div>

--- a/templates/homepage-ecosystem-band.tmpl
+++ b/templates/homepage-ecosystem-band.tmpl
@@ -1,8 +1,8 @@
-<div class="grid-wrapper homepage-ecosystem-band">
+<div class="grid-wrapper homepage-ecosystem-band" id="ecosystem">
   <div class="width-12-12 width-12-12-m">
     <div class="section-title">
       <div class="section-top">
-        <img class="section-icon" src="/assets/images/communities.svg" />
+        <img class="section-icon" src="{{ homepage.ecosystem.section_icon }}" />
         <h2>{{ homepage.ecosystem.title }}</h2>
         <div class="section-view-more">
           <a href="{{ homepage.ecosystem.url }}">{{ homepage.labels.view_more }}&nbsp;<i class="fa fa-arrow-circle-right" aria-hidden="true"></i></a>

--- a/templates/homepage-events-band.tmpl
+++ b/templates/homepage-events-band.tmpl
@@ -1,8 +1,8 @@
-<div class="grid-wrapper homepage-events-band">
+<div class="grid-wrapper homepage-events-band" id="events">
   <div class="width-12-12 width-12-12-m">
     <div class="section-title">
       <div class="section-top">
-        <img class="section-icon" src="/assets/images/calendar.svg" />
+        <img class="section-icon" src="{{ homepage.events.section_icon }}" />
         <h2>{{ homepage.events.title }}</h2>
         <div class="section-view-more">
           <a href="{{ homepage.events.url }}">{{ homepage.events.view_calendar }}&nbsp;<i class="fa fa-calendar-check" aria-hidden="true"></i></a>

--- a/templates/homepage-platform-band.tmpl
+++ b/templates/homepage-platform-band.tmpl
@@ -1,6 +1,6 @@
 <div class="grid-wrapper homepage-platform-band" id="platform">
   <div class="width-4-12 width-12-12-m">
-    <img class="page-logo" src="/images/platform.svg">
+    <img class="page-logo" src="{{ homepage.platform.section_icon }}">
   </div>
   <div class="width-8-12 width-12-12-m">
     <p>{{ homepage.platform.main }}</p>

--- a/templates/homepage-tab-menu-band.tmpl
+++ b/templates/homepage-tab-menu-band.tmpl
@@ -1,0 +1,54 @@
+<div class="grid-wrapper homepage-tab-menu-band">
+  <div class="width-12-12 width-12-12-m">
+    <div class="tab-menu-row">
+      <div class="tab-menu-box">
+        <!-- Automate menu button -->
+        <a href="#automate">
+          <button class="btn text-nowrap">
+            <img src="{{ homepage.automate.section_icon }}" />&nbsp;{{ homepage.automate.title }}
+          </button>
+        </a>
+      </div>
+      <div class="tab-menu-box">
+        <!-- Ecosystem menu button -->
+        <a href="#ecosystem">
+          <button class="btn text-nowrap">
+            <img src="{{ homepage.ecosystem.section_icon }}" />&nbsp;{{ homepage.ecosystem.title }}
+          </button>
+        </a>
+      </div>
+      <div class="tab-menu-box">
+        <!-- Community menu button -->
+        <a href="#community">
+          <button class="btn text-nowrap">
+            <img src="{{ homepage.community.section_icon }}" />&nbsp;{{ homepage.community.title }}
+          </button>
+        </a>
+      </div>
+      <div class="tab-menu-box">
+        <!-- Blog menu item -->
+        <a href="#blog">
+          <button class="btn text-nowrap">
+            <img src="{{ homepage.blog.section_icon }}" />&nbsp;{{ homepage.blog.title }}
+          </button>
+        </a>
+      </div>
+      <div class="tab-menu-box">
+        <!-- Contribute menu item -->
+        <a href="#contribute">
+          <button class="btn text-nowrap">
+            <img src="{{ homepage.contribute.section_icon }}" />&nbsp;{{ homepage.contribute.title }}
+          </button>
+        </a>
+      </div>
+      <div class="tab-menu-box">
+        <!-- Events menu item -->
+        <a href="#events">
+          <button class="btn text-nowrap">
+            <img src="{{ homepage.events.section_icon }}" />&nbsp;{{ homepage.events.title }}
+          </button>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/homepage.tmpl
+++ b/templates/homepage.tmpl
@@ -2,6 +2,7 @@
 {% block content %}
   <div class="container">
     {% include 'homepage-banner-band.tmpl' %}
+    {% include 'homepage-tab-menu-band.tmpl' %}
     {% include 'homepage-automate-band.tmpl' %}
     {% include 'homepage-ecosystem-band.tmpl' %}
     {% include 'homepage-community-band.tmpl' %}

--- a/themes/ansible-community/sass/_homepage-tab-menu-band.scss
+++ b/themes/ansible-community/sass/_homepage-tab-menu-band.scss
@@ -1,0 +1,33 @@
+.homepage-tab-menu-band {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+  gap: 20px;
+  background-color: $grey94;
+}
+
+.tab-menu-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+}
+
+.tab-menu-box {
+  a {
+    text-decoration: none;
+  }
+  .btn {
+    display: flex;
+    padding: 20px;
+    font-size: 0.9rem;
+    align-items: center;
+  }
+  img {
+    float: left;
+    width: auto;
+    height: 40px;
+  }
+  &:hover {
+    background-color: $white;
+    color: $navy;
+  }
+}

--- a/themes/ansible-community/sass/main.scss
+++ b/themes/ansible-community/sass/main.scss
@@ -9,6 +9,7 @@
 @import "homepage-back-to-top";
 @import "homepage-get-started";
 @import "homepage-banner-band";
+@import "homepage-tab-menu-band";
 @import "homepage-automate-band";
 @import "homepage-ecosystem-band";
 @import "homepage-community-band";


### PR DESCRIPTION
Fixes issue #78 

I kind of like this navigation now after playing around with it. We need to add "Back to Top" to the platform band but we should do that in a follow up.

Also I added "Events" and feel we should remove it from the top-level navigation and avoid duplication with the tab menu. Again, will do that in a follow up.

This is going to add some complexity on mobile but we can probably just add a media query to hide the row when display drops to a certain size. In those cases I think we should expect users to want to scroll.