### PR TITLE
Create homepage container class

### DIFF
--- a/templates/homepage.tmpl
+++ b/templates/homepage.tmpl
@@ -6,7 +6,7 @@
   </div>
 {% endblock %}
 {% block content %}
-  <div class="container">
+  <div class="homepage">
     {% include 'homepage-tab-menu-band.tmpl' %}
     {% include 'homepage-automate-band.tmpl' %}
     {% include 'homepage-ecosystem-band.tmpl' %}

--- a/themes/ansible-community/sass/_homepage-container.scss
+++ b/themes/ansible-community/sass/_homepage-container.scss
@@ -1,0 +1,5 @@
+.homepage-container {
+  max-width: fit-content;
+  padding-left: 13rem;
+  padding-right: 13rem;
+}

--- a/themes/ansible-community/sass/main.scss
+++ b/themes/ansible-community/sass/main.scss
@@ -4,6 +4,7 @@
 @import "nav-bar";
 @import "font-awesome";
 @import "hero-container";
+@import "homepage-container";
 @import "homepage-section-title";
 @import "homepage-back-to-top";
 @import "homepage-get-started";

--- a/themes/ansible-community/templates/base.tmpl
+++ b/themes/ansible-community/templates/base.tmpl
@@ -18,7 +18,7 @@
   {% include 'base_nav.tmpl' %}
 {% endif %}
 
-<div class="container" id="content" role="main">
+<div {% if permalink == '/' %}class="homepage-container"{% else %}class="container"{% endif %} id="content" role="main">
     <div class="body-content">
         <!--Body content-->
         {{ template_hooks['page_header']() }}


### PR DESCRIPTION
Fixes https://github.com/ansible-community/community-website/issues/132

Note that this doesn't really do that much but lays the groundwork for some work related to layout. This new class gives us better control over the responsiveness of the homepage. Blogs and secondary pages can continue to use bootstrap.