### PR TITLE
Use bootstrap for secondary page navbar

### DIFF
--- a/themes/ansible-community/sass/_hero-container.scss
+++ b/themes/ansible-community/sass/_hero-container.scss
@@ -1,5 +1,7 @@
 .hero-container {
   max-width: 100%;
+  padding-left: 2rem;
+  padding-right: 2rem;
   background-image: url(../images/unsplash.jpg);
   background-size: 100%;
   background-color: $pool;

--- a/themes/ansible-community/templates/base_nav.tmpl
+++ b/themes/ansible-community/templates/base_nav.tmpl
@@ -18,7 +18,7 @@ bg-dark
 {% endif %}
 {% endif %}
 ">
-    <div class="masthead"><!-- This keeps the margins nice -->
+    <div {% if permalink == '/' %}class="masthead"{% else %}class="container"{% endif %}><!-- This keeps the margins nice -->
         <a class="navbar-brand" href="{{ _link("root", None, lang) }}">
         {% if logo_url %}
             <img src="{{ logo_url }}" alt="{{ blog_title|e }}" id="logo" class="d-inline-block align-top">


### PR DESCRIPTION
Fixes #137 so that secondary pages such as the blog use the bootstrap container and only the homepage uses the masthead.