### PR TITLE
Six column ecosystem

### DIFF
--- a/data/homepage.yaml
+++ b/data/homepage.yaml
@@ -93,26 +93,25 @@ ecosystem:
   title: Ecosystem
   intro: Projects in the Ansible ecosystem let you expand automation to a virtually unlimited set of use cases.
   url: https://docs.ansible.com/ecosystem.html
-  top_row:
+  projects:
     awx:
       heading: AWX
-      description: A web-based user interface, REST API, and task engine for Ansible automation.
+      description: Web-based user interface, REST API, and task engine for performing Ansible automation.
       link: https://ansible.readthedocs.io/projects/awx/
       logo: logo-awx.svg
     runner:
       heading: Ansible Runner
-      description: A stable and consistent interface abstraction to Ansible execution.
+      description: An interface abstraction to Ansible that offers reliable and consistent task execution.
       link: https://ansible.readthedocs.io/projects/runner/
       logo: logo-runner.svg
-  bottom_row:
     builder:
       heading: Ansible Builder
-      description: Configure and build portable, consistent, customized Ansible control nodes.
+      description: Tooling to configure and build customized Ansible control nodes in container images.
       link: https://ansible.readthedocs.io/projects/builder/
       logo: logo-builder.svg
     eda:
-      heading: Event-Driven Ansible Server
-      description: Scalable and flexible automation that can subscribe to a wide variety of event sources.
+      heading: Event-Driven Ansible
+      description: Subscribe to event sources to scale automation and deliver more efficient IT operations.
       link: https://ansible.readthedocs.io/projects/rulebook/
       logo: logo-eda.svg
 blog:

--- a/templates/homepage-automate-band.tmpl
+++ b/templates/homepage-automate-band.tmpl
@@ -15,6 +15,6 @@
       <p>{{ homepage.automate.bottom_section.paragraphs.simple }}</p>
     </div>
     {% include 'homepage-get-started.tmpl' %}
-    {% include 'homepage-back-to-top.tmpl' %}
   </div>
+  {% include 'homepage-back-to-top.tmpl' %}
 </div>

--- a/templates/homepage-back-to-top.tmpl
+++ b/templates/homepage-back-to-top.tmpl
@@ -1,3 +1,5 @@
-<div class="back-to-top">
-  <a href="#top">{{ homepage.labels.back_to_top }}&ensp;<i class="fa fa-arrow-up" aria-hidden="true"></i></a>
+<div class="width-12-12 width-12-12-m">
+  <div class="back-to-top">
+    <a href="#top">{{ homepage.labels.back_to_top }}&ensp;<i class="fa fa-arrow-up" aria-hidden="true"></i></a>
+  </div>
 </div>

--- a/templates/homepage-blog-band.tmpl
+++ b/templates/homepage-blog-band.tmpl
@@ -17,6 +17,6 @@
         {{ post.text() }}
       {% endblock %}
     </div>
-    {% include 'homepage-back-to-top.tmpl' %}
   </div>
+  {% include 'homepage-back-to-top.tmpl' %}
 </div>

--- a/templates/homepage-community-band.tmpl
+++ b/templates/homepage-community-band.tmpl
@@ -18,6 +18,6 @@
         {% endfor %}
       </div>
     </div>
-    {% include 'homepage-back-to-top.tmpl' %}
   </div>
+  {% include 'homepage-back-to-top.tmpl' %}
 </div>

--- a/templates/homepage-contribute-band.tmpl
+++ b/templates/homepage-contribute-band.tmpl
@@ -23,6 +23,6 @@
         <img src="/images/bull-builder.svg" alt="Ansible bull builder mascot." />
       </div>
     </div>
-    {% include 'homepage-back-to-top.tmpl' %}
   </div>
+  {% include 'homepage-back-to-top.tmpl' %}
 </div>

--- a/templates/homepage-ecosystem-band.tmpl
+++ b/templates/homepage-ecosystem-band.tmpl
@@ -10,30 +10,18 @@
       </div>
       <p>{{ homepage.ecosystem.intro }}</p>
     </div>
-    <div class="ecosystem-row">
-      {% for key, item in homepage.ecosystem.top_row.items() %}
-      <div class="ecosystem-card">
-        <div class="ecosystem-content">
-          <h3>{{ item.heading }}</h3>
-          <p>{{ item.description }}</p>
-          <a class="btn" href="{{ item.link }}" role="button">{{ homepage.labels.learn_more }}</a>
-        </div>
-        <img class="ecosystem-logo" src="/images/{{ item.logo }}" />
-      </div>
-      {% endfor %}
-    </div>
-    <div class="ecosystem-row">
-      {% for key, item in homepage.ecosystem.bottom_row.items() %}
-      <div class="ecosystem-card">
-        <div class="ecosystem-content">
-          <h3>{{ item.heading }}</h3>
-          <p>{{ item.description }}</p>
-          <a class="btn" href="{{ item.link }}" role="button">{{ homepage.labels.learn_more }}</a>
-        </div>
-        <img class="ecosystem-logo" src="/images/{{ item.logo }}" />
-      </div>
-      {% endfor %}
-    </div>
-    {% include 'homepage-back-to-top.tmpl' %}
   </div>
+  {% for key, item in homepage.ecosystem.projects.items() %}
+  <div class="width-6-12 width-12-12-m">
+    <div class="ecosystem-card">
+      <div class="ecosystem-content">
+        <h3>{{ item.heading }}</h3>
+        <p>{{ item.description }}</p>
+        <a class="btn" href="{{ item.link }}" role="button">{{ homepage.labels.learn_more }}</a>
+      </div>
+      <img class="ecosystem-logo" src="/images/{{ item.logo }}" width="95" height="95"/>
+    </div>
+  </div>
+  {% endfor %}
+  {% include 'homepage-back-to-top.tmpl' %}
 </div>

--- a/themes/ansible-community/sass/_homepage-back-to-top.scss
+++ b/themes/ansible-community/sass/_homepage-back-to-top.scss
@@ -1,7 +1,6 @@
 .back-to-top {
-  margin-top: 2rem;
   grid-row: 4;
-  font-family: $redhat-display;
-  font-size: 0.9rem;
+  padding-top: 0%;
+  font-size: 1rem;
   text-transform: none;
 }

--- a/themes/ansible-community/sass/_homepage-ecosystem-band.scss
+++ b/themes/ansible-community/sass/_homepage-ecosystem-band.scss
@@ -1,33 +1,30 @@
 .homepage-ecosystem-band {
-  padding: 2rem;
+  padding: 1rem;
   background-color: $grey94;
-}
-
-.ecosystem-row {
-  grid-column: span 2;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  margin: 1rem;
-  gap: 1.2rem;
+  gap: 2rem;
 }
 
 .ecosystem-card {
   display: flex;
+  height: 160px;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
   transition: 0.3s;
-  padding: 2px 10px;
+  padding: 1rem;
   border-width: 1px;
   border-radius: 5px;
   background-color: $white;
   &:hover {
     box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.2);
   }
+  @media screen and (max-width: 992px) {
+    height: max-content;
+  }
 }
 
 .ecosystem-content {
   display: flex;
   flex-direction: column;
-  padding: 6px 2px;
+  width: 80%;
   h3 {
     font-size: 1rem;
     font-weight: 600;
@@ -59,7 +56,9 @@
 }
 
 .ecosystem-logo {
+  width: 20%;
   float: right;
-  width: 95px;
-  height: 95px;
+  @media screen and (max-width: 992px) {
+    display: none;
+  }
 }


### PR DESCRIPTION
Relates to issue #47 

This PR removes the rows from the ecosystem section to improve responsiveness. My original design was flawed. I created two rows with two columns each. It is much more straightforward to put each card in a div that takes up six columns. Given that it's a 12 column layout and 4 projects defined in the ecosystem data then we'll always get two rows of cards side by side. With the old design we'll need to define a lot more breakpoints to get the cards in each row to stack properly. With the new layout that will just happen a lot easier.

I've started with the media breakpoints and queries and there is a lot more we can do there but I'd prefer to do the rest of the media queries in a follow up. I'm also hoping to get help from someone who is a lot better at that.

This PR also updates the "back to top" button so it is in its own 12 column grid. That makes it easier to include the "back to top" button consistently. Before, when we had the bullhorn included as part of the community div we had a bit of a deviation to how the "back to top" button was included. This change will also make it easier to fix that if we flip flop back.