### PR TITLE
Design feedback on blogs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -967,7 +967,8 @@ INDEX_TEASERS = True
 # }}                            A literal } (U+007D RIGHT CURLY BRACKET)
 
 # 'Read more...' for the index page, if INDEX_TEASERS is True (translatable)
-INDEX_READ_MORE_LINK = '<p class="more"><a href="{link}">{read_more}…</a></p>'
+#INDEX_READ_MORE_LINK = '<p class="more"><a href="{link}">{read_more}…</a></p>'
+INDEX_READ_MORE_LINK = ''
 # 'Read more...' for the feeds, if FEED_TEASERS is True (translatable)
 FEED_READ_MORE_LINK = '<p><a href="{link}">{read_more}…</a> ({min_remaining_read})</p>'
 

--- a/themes/ansible-community/sass/_homepage-blog-band.scss
+++ b/themes/ansible-community/sass/_homepage-blog-band.scss
@@ -23,11 +23,15 @@
   p {
     text-align: left;
   }
+  img {
+    display: none;
+  }
 }
 
 .blog-author {
   p {
-    font-size: 1.0rem;
-    text-align: right;
+    font-size: 1rem;
+    text-align: left;
+    padding-bottom: 10px;
   }
 }


### PR DESCRIPTION
Fixes issue #163

Removes the redundant "read more" link on blog posts on the index. Note that modifying the `INDEX_READ_MORE_LINK` means that no HTML is inserted into the homepage. We could use `display: none` in the style sheet to hide the "read more" link but that doesn't seem like the most accessible option to me. It's better to just not insert it than to hide it.

On that note the other change here - apart from some minor style changes - is to hide images on the blog posts on the index page. In cases like the bullhorn, if one post has an image but the other posts don't then the whole blog section looks out of balance. I could also imagine a scenario where someone includes a large graphic like an architecture diagram or something that could totally blow up the blog section.

It doesn't look like there's any way to exclude images with Nikola's ``post-list`` shortcode so simply not displaying the image seems like the best (most straightforward) way forward. It's still there so screenreaders will detect it but the alt text is available so shouldn't be a huge issue.