### PR TITLE
Design feedback on fonts and banner

### DIFF
--- a/data/homepage.yaml
+++ b/data/homepage.yaml
@@ -2,8 +2,10 @@ banner:
   title: Automation Powered by People
   intro: Configure most operating systems, deploy software, and orchestrate advanced workflows to support application deployment, system updates, and more!
   pip_install: pip install ansible
-  latest_version: Ansible 7 is now available.
-  how_to_install: Install by copying the pip command.
+  install_tooltip: Copy the pip command to install Ansible.
+  latest_version: Ansible 7 is now available!
+  copy_command: Copy the "pip install ansible" command.
+  copy_success_message: Successfully copied to clipboard!
   redhat_logo_alt: Red Hat Ansible Automation product logo.
   welcome_alt: Bullito the Ansible community mascot welcomes you.
 automate:
@@ -151,6 +153,7 @@ labels:
   view_more: View more
   back_to_top: Back to top
   get_started: Get started with Ansible
+  get_started_tooltip: Quickly get up and running with Ansible automation.
 links:
   ansible:
     get_started_url: https://docs.ansible.com/ansible/latest/getting_started/index.html

--- a/data/homepage.yaml
+++ b/data/homepage.yaml
@@ -1,11 +1,9 @@
 banner:
-  title: Automation Powered by People
+  title: Automation powered by people
   intro: Configure most operating systems, deploy software, and orchestrate advanced workflows to support application deployment, system updates, and more!
   pip_install: pip install ansible
-  install_tooltip: Copy the pip command to install Ansible.
-  latest_version: Ansible 7 is now available!
-  copy_command: Copy the "pip install ansible" command.
-  copy_success_message: Successfully copied to clipboard!
+  install_tooltip: Copy the pip command to install the latest version of Ansible.
+  copy_success_message: Copied!
   redhat_logo_alt: Red Hat Ansible Automation product logo.
   welcome_alt: Bullito the Ansible community mascot welcomes you.
 automate:

--- a/templates/homepage-banner-band.tmpl
+++ b/templates/homepage-banner-band.tmpl
@@ -10,16 +10,11 @@
             <button class="btn text-nowrap"
                     data-clipboard-text="{{ homepage.banner.pip_install }}"
                     title="{{ homepage.banner.install_tooltip }}">
-              <div id="clipboard-popup" class="popup hidden">
-                <p>{{ homepage.banner.copy_success_message }}</p>
-              </div>
-              <i class="fa fa-copy" aria-hidden="true" />&ensp;
-              <p>
-                {{ homepage.banner.latest_version }}
-                <br />
-                {{ homepage.banner.copy_command }}
-              </p>
+              {{ homepage.banner.pip_install }}&ensp;<i class="fa fa-copy" aria-hidden="true" />
             </button>
+            <div id="clipboard-popup" class="popup hidden">
+              <p>{{ homepage.banner.copy_success_message }}</p>
+            </div>
           </div>
         </div>
         <div class="banner-platform-learn">
@@ -30,7 +25,7 @@
                  width="20"
                  height="20" />
             &ensp;{{ homepage.platform.learn }}
-            &ensp;<i class="fa fa-arrow-right" aria-hidden="true" />
+            <i class="fa fa-arrow-right" aria-hidden="true" />
           </a>
         </div>
       </div>

--- a/templates/homepage-banner-band.tmpl
+++ b/templates/homepage-banner-band.tmpl
@@ -8,16 +8,18 @@
           {% include "homepage-get-started.tmpl" %}
           <div class="banner-clipboard">
             <button class="btn text-nowrap"
-                    data-clipboard-text="{{ homepage.banner.pip_install }}">
-              <code>{{ homepage.banner.pip_install }}</code>&ensp;<i class="fa fa-copy" aria-hidden="true" />
+                    data-clipboard-text="{{ homepage.banner.pip_install }}"
+                    title="{{ homepage.banner.install_tooltip }}">
+              <div id="clipboard-popup" class="popup hidden">
+                <p>{{ homepage.banner.copy_success_message }}</p>
+              </div>
+              <i class="fa fa-copy" aria-hidden="true" />&ensp;
+              <p>
+                {{ homepage.banner.latest_version }}
+                <br />
+                {{ homepage.banner.copy_command }}
+              </p>
             </button>
-          </div>
-          <div class="banner-latest-version">
-            <p>
-              {{ homepage.banner.latest_version }}
-              <br />
-              {{ homepage.banner.how_to_install }}
-            </p>
           </div>
         </div>
         <div class="banner-platform-learn">
@@ -28,6 +30,7 @@
                  width="20"
                  height="20" />
             &ensp;{{ homepage.platform.learn }}
+            &ensp;<i class="fa fa-arrow-right" aria-hidden="true" />
           </a>
         </div>
       </div>

--- a/templates/homepage-blog-band.tmpl
+++ b/templates/homepage-blog-band.tmpl
@@ -9,7 +9,7 @@
              height="40" />
         <h2>{{ homepage.blog.title }}</h2>
         <div class="section-view-more">
-          <a href="{{ homepage.blog.url }}">{{ homepage.labels.view_more }}&ensp;<i class="fa fa-arrow-circle-right"></i></a>
+          <a href="{{ homepage.blog.url }}">{{ homepage.labels.view_more }}&ensp;<i class="fa fa-arrow-right"></i></a>
         </div>
       </div>
       <p>{{ homepage.blog.intro }}</p>

--- a/templates/homepage-ecosystem-band.tmpl
+++ b/templates/homepage-ecosystem-band.tmpl
@@ -10,7 +10,7 @@
              height="40" />
         <h2>{{ homepage.ecosystem.title }}</h2>
         <div class="section-view-more">
-          <a href="{{ homepage.ecosystem.url }}">{{ homepage.labels.view_more }}&ensp;<i class="fa fa-arrow-circle-right" aria-hidden="true"></i></a>
+          <a href="{{ homepage.ecosystem.url }}">{{ homepage.labels.view_more }}&ensp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a>
         </div>
       </div>
       <p>{{ homepage.ecosystem.intro }}</p>

--- a/templates/homepage-events-band.tmpl
+++ b/templates/homepage-events-band.tmpl
@@ -9,7 +9,7 @@
              height="40" />
         <h2>{{ homepage.events.title }}</h2>
         <div class="section-view-more">
-          <a href="{{ homepage.events.url }}">{{ homepage.events.view_calendar }}&ensp;<i class="fa fa-calendar-check" aria-hidden="true"></i></a>
+          <a href="{{ homepage.events.url }}">{{ homepage.events.view_calendar }}&ensp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a>
         </div>
       </div>
       <p>{{ homepage.events.intro }}</p>

--- a/templates/homepage-get-started.tmpl
+++ b/templates/homepage-get-started.tmpl
@@ -1,7 +1,6 @@
 <div class="get-started-ansible">
   <a href="{{ homepage.links.ansible.get_started_url }}" target="_blank">
-    <button class="btn text-nowrap">
-      <i class="fa fa-rocket"></i>&ensp;{{ homepage.labels.get_started }}
-    </button>
+    <button class="btn text-nowrap"
+            title="{{ homepage.labels.get_started_tooltip }}">{{ homepage.labels.get_started }}</button>
   </a>
 </div>

--- a/themes/ansible-community/assets/js/clipboard.js
+++ b/themes/ansible-community/assets/js/clipboard.js
@@ -4,6 +4,16 @@ clipboard.on('success', function (e) {
   console.info('Action:', e.action);
   console.info('Text:', e.text);
   console.info('Trigger:', e.trigger);
+
+  // Display the "Copied" popup text
+  var popup = document.getElementById('clipboard-popup');
+  popup.classList.remove('hidden');
+
+  // Hide after 2 seconds
+  setTimeout(function() {
+    popup.classList.add('hidden');
+  }, 2000);
+
 });
 
 clipboard.on('error', function (e) {

--- a/themes/ansible-community/sass/_font-awesome.scss
+++ b/themes/ansible-community/sass/_font-awesome.scss
@@ -2,8 +2,11 @@
   margin-right: 4px;
 }
 
-.fa-arrow-circle-right {
-  color: $navy;
+.fa-arrow-up {
+  background-color: transparent;
+}
+
+.fa-arrow-right {
   background-color: transparent;
 }
 

--- a/themes/ansible-community/sass/_homepage-automate-band.scss
+++ b/themes/ansible-community/sass/_homepage-automate-band.scss
@@ -4,14 +4,12 @@
 
 .automate-content {
   h3 {
-    font-family: $redhat-display;
     font-size: 1.2rem;
     font-weight: bold;
     margin-top: 0;
     margin-bottom: 0;
   }
   p {
-    font-family: $redhat-display;
     font-size: 1rem;
     font-weight: normal;
     margin-top: 24px;

--- a/themes/ansible-community/sass/_homepage-banner-band.scss
+++ b/themes/ansible-community/sass/_homepage-banner-band.scss
@@ -21,6 +21,7 @@
 }
 
 .banner-main-content {
+  width: fit-content;
   border-radius: 10px;
   background-color: $white;
   padding: 2rem;
@@ -45,34 +46,40 @@
 
 .banner-clipboard {
   display: flex;
-  font-size: 0.9rem;
   .btn {
     display: flex;
     flex-direction: row;
-    font-size: 0.9rem;
-    text-align: left;
     background-color: $white !important;
-    border-width: 0;
-    border-color: transparent;
-  }
-  code {
     color: $cyan !important;
+    border-width: 1px;
+    border-radius: 2px;
+    border-color: $cyan !important;
+    margin-right: 1px;
+    font-family: "Courier New", Courier, monospace;
+    font-size: 0.8rem;
+    align-items: center;
     &:hover {
-      color: $cyan !important;
-    }
-  }
-  .fa-copy {
-    color: $cyan;
-    font-size: 20px;
-    padding-top: 10px;
-    background-color: transparent;
-    &:hover {
-      color: $cyan !important;
+      background-color: $cyan !important;
+      color: $white !important;
     }
   }
   @media screen and (max-width: 768px) {
     display: none;
   }
+}
+
+.popup {
+  display: flex;
+  padding: 0 3px;
+  background-color: $black !important;
+  color: $grey94 !important;
+  border-radius: 1px;
+  font-size: 0.8rem;
+  align-items: center;
+}
+
+.popup.hidden {
+  display: none;
 }
 
 .banner-platform-learn {
@@ -82,25 +89,6 @@
   & > a {
     color: $black;
   }
-}
-
-.popup {
-  display: inline-block;
-  position: absolute;
-  top: 190px;
-  background-color: $black !important;
-  padding: 3px;
-  border-radius: 1px;
-  p {
-    color: $grey94 !important;
-    &:hover {
-      color: $grey94 !important;
-    }
-  }
-}
-
-.popup.hidden {
-  display: none;
 }
 
 .banner-redhat-logo {

--- a/themes/ansible-community/sass/_homepage-banner-band.scss
+++ b/themes/ansible-community/sass/_homepage-banner-band.scss
@@ -14,7 +14,7 @@
 }
 
 .banner-welcome-image {
-flex: 1;
+  flex: 1;
   img {
     margin-left: 125px;
   }
@@ -26,51 +26,45 @@ flex: 1;
   padding: 2rem;
   flex: 1;
   h2 {
-    font-family: $redhat-display;
     font-size: 2rem;
-    font-weight: bold;
+    font-weight: 600;
+    text-decoration: solid;
   }
-  & > p{
-    font-family: $redhat-display;
+  & > p {
+    padding-top: 12px;
     font-size: 1rem;
-    font-weight: bold;
+    font-weight: 500;
+    text-decoration: solid;
   }
 }
 
-.banner-main-row  {
+.banner-main-row {
   display: flex;
   flex-wrap: nowrap;
-  & > *{
-    flex: 1;
-    width: 100%;
-  }
-  & > button {
-    font-weight: bold;
-  }
-
 }
 
 .banner-clipboard {
   display: flex;
-  align-items: center;
   font-size: 0.9rem;
-  text-align: left;
-  padding-right: 1rem;
   .btn {
+    display: flex;
+    flex-direction: row;
     font-size: 0.9rem;
+    text-align: left;
     background-color: $white !important;
-    border-width: 1px;
-    border-radius: 2px;
-    border-color: $cyan !important;
+    border-width: 0;
+    border-color: transparent;
   }
   code {
-    color: $navy !important;
+    color: $cyan !important;
     &:hover {
       color: $cyan !important;
     }
   }
   .fa-copy {
-    color: $navy;
+    color: $cyan;
+    font-size: 20px;
+    padding-top: 10px;
     background-color: transparent;
     &:hover {
       color: $cyan !important;
@@ -81,24 +75,34 @@ flex: 1;
   }
 }
 
-.banner-latest-version {
-  font-size: 0.8rem;
-  @media screen and (max-width: 768px) {
-    display: none;
+.banner-platform-learn {
+  font-weight: bold;
+  font-size: 1rem;
+  padding-top: 1rem;
+  & > a {
+    color: $black;
   }
 }
 
-.banner-platform-learn {
-  font-family: $redhat-display;
-  font-weight:bold;
-  font-size: 0.9rem;
-  padding-top: 1rem;
-  & > a {
-    color:black
+.popup {
+  display: inline-block;
+  position: absolute;
+  top: 190px;
+  background-color: $black !important;
+  padding: 3px;
+  border-radius: 1px;
+  p {
+    color: $grey94 !important;
+    &:hover {
+      color: $grey94 !important;
+    }
   }
+}
+
+.popup.hidden {
+  display: none;
 }
 
 .banner-redhat-logo {
   margin-left: 10px;
 }
-

--- a/themes/ansible-community/sass/_homepage-blog-band.scss
+++ b/themes/ansible-community/sass/_homepage-blog-band.scss
@@ -16,7 +16,6 @@
   flex: 1;
   padding-right: 20px;
   h3 {
-    font-family: $redhat-display;
     font-size: 1.5rem;
     text-transform: none;
   }

--- a/themes/ansible-community/sass/_homepage-events-band.scss
+++ b/themes/ansible-community/sass/_homepage-events-band.scss
@@ -22,14 +22,12 @@
   flex: 1;
   padding-right: 20px;
   a {
-    font-family: $redhat-display;
     font-size: 1rem;
     color: $black;
     text-transform: none;
   }
   h3 {
     margin-top: 20px;
-    font-family: $redhat-display;
     font-size: 1.5rem;
     text-transform: none;
   }

--- a/themes/ansible-community/sass/_homepage-section-title.scss
+++ b/themes/ansible-community/sass/_homepage-section-title.scss
@@ -2,12 +2,10 @@
   display: flex;
   flex-direction: column;
   h2 {
-    font-family: $redhat-display;
     font-size: 1.8rem;
     text-transform: none;
   }
   p {
-    font-family: $redhat-display;
     font-size: 1rem;
     text-transform: none;
     padding: 1rem 0;
@@ -27,8 +25,7 @@
 }
 
 .section-view-more {
-  font-family: $redhat-display;
-  font-size: 0.9rem;
+  font-size: 1rem;
   text-transform: none;
   margin-left: auto;
 }

--- a/themes/ansible-community/sass/main.scss
+++ b/themes/ansible-community/sass/main.scss
@@ -25,7 +25,7 @@ body {
   background: $white;
   color: $black;
   font-weight: normal;
-  font-family: $redhat-text;
+  font-family: $redhat-display;
   position: relative;
   min-height: 100vh;
 }

--- a/themes/ansible-community/templates/base_nav_button.tmpl
+++ b/themes/ansible-community/templates/base_nav_button.tmpl
@@ -1,7 +1,5 @@
 <div class="get-started-nav">
   <a href="{{ homepage.links.ansible.get_started_url }}" target="_blank">
-    <button class="btn text-nowrap">
-      <i class="fa fa-rocket"></i>&ensp;{{ homepage.labels.get_started }}
-    </button>
+    <button class="btn text-nowrap">{{ homepage.labels.get_started }}</button>
   </a>
 </div>


### PR DESCRIPTION
Fixes issue #159 

- Use Red Hat display as the font family globally.
- Adjust font weight on main banner content.
- Add tooltips to install and get started buttons.
- Move "Install by copying" text to tooltip.
- Add popup to make it clear when text is copied.
- Add right arrows to platform learn more in banner.
- Use fa right arrow instead of circle right arrow.
- Avoid increasing space between buttons when resizing page.