### PR TITLE
Create homepage container

### DIFF
--- a/templates/homepage-automate-band.tmpl
+++ b/templates/homepage-automate-band.tmpl
@@ -1,4 +1,4 @@
-<div class="grid-wrapper homepage-automate-band" id="automate">
+<div class="grid-wrapper homepage-automate-band homepage-body" id="automate">
   <div class="width-12-12 width-12-12-m">
     <div class="section-title">
       <div class="section-top">

--- a/templates/homepage-blog-band.tmpl
+++ b/templates/homepage-blog-band.tmpl
@@ -1,4 +1,4 @@
-<div class="grid-wrapper homepage-blog-band" id="blog">
+<div class="grid-wrapper homepage-blog-band homepage-body" id="blog">
   <div class="width-12-12 width-12-12-m">
     <div class="section-title">
       <div class="section-top">

--- a/templates/homepage-bullhorn-band.tmpl
+++ b/templates/homepage-bullhorn-band.tmpl
@@ -1,4 +1,4 @@
-<div class="grid-wrapper homepage-bullhorn-band">
+<div class="grid-wrapper homepage-bullhorn-band homepage-body">
   <div class="width-12-12 width-12-12-m">
     <div class="bullhorn-content">
       <div class="bullhorn-image">

--- a/templates/homepage-community-band.tmpl
+++ b/templates/homepage-community-band.tmpl
@@ -1,4 +1,4 @@
-<div class="grid-wrapper homepage-community-band" id="community">
+<div class="grid-wrapper homepage-community-band homepage-body" id="community">
   <div class="width-12-12 width-12-12-m">
     <div class="section-title">
       <div class="section-top">

--- a/templates/homepage-contribute-band.tmpl
+++ b/templates/homepage-contribute-band.tmpl
@@ -1,4 +1,4 @@
-<div class="grid-wrapper homepage-contribute-band" id="contribute">
+<div class="grid-wrapper homepage-contribute-band homepage-body" id="contribute">
   <div class="width-12-12 width-12-12-m">
     <div class="section-title">
       <div class="section-top">

--- a/templates/homepage-ecosystem-band.tmpl
+++ b/templates/homepage-ecosystem-band.tmpl
@@ -1,4 +1,4 @@
-<div class="grid-wrapper homepage-ecosystem-band" id="ecosystem">
+<div class="grid-wrapper homepage-ecosystem-band homepage-body" id="ecosystem">
   <div class="width-12-12 width-12-12-m">
     <div class="section-title">
       <div class="section-top">

--- a/templates/homepage-events-band.tmpl
+++ b/templates/homepage-events-band.tmpl
@@ -1,4 +1,4 @@
-<div class="grid-wrapper homepage-events-band" id="events">
+<div class="grid-wrapper homepage-events-band homepage-body" id="events">
   <div class="width-12-12 width-12-12-m">
     <div class="section-title">
       <div class="section-top">

--- a/templates/homepage-platform-band.tmpl
+++ b/templates/homepage-platform-band.tmpl
@@ -1,4 +1,4 @@
-<div class="grid-wrapper homepage-platform-band" id="platform">
+<div class="grid-wrapper homepage-platform-band homepage-body" id="platform">
   <div class="width-12-12 width-12-12-m">
       <div class="platform-row">
         <div class="platform-box-left">

--- a/templates/homepage-tab-menu-band.tmpl
+++ b/templates/homepage-tab-menu-band.tmpl
@@ -1,4 +1,4 @@
-<div class="grid-wrapper homepage-tab-menu-band">
+<div class="grid-wrapper homepage-tab-menu-band homepage-body">
   <div class="width-12-12 width-12-12-m">
     <div class="tab-menu-row">
       <div class="tab-menu-box">

--- a/templates/homepage.tmpl
+++ b/templates/homepage.tmpl
@@ -5,16 +5,14 @@
     {% include 'homepage-banner-band.tmpl' %}
   </div>
 {% endblock %}
-{% block content %}
-  <div class="homepage">
-    {% include 'homepage-tab-menu-band.tmpl' %}
-    {% include 'homepage-automate-band.tmpl' %}
-    {% include 'homepage-ecosystem-band.tmpl' %}
-    {% include 'homepage-community-band.tmpl' %}
-    {% include 'homepage-blog-band.tmpl' %}
-    {% include 'homepage-contribute-band.tmpl' %}
-    {% include 'homepage-bullhorn-band.tmpl' %}
-    {% include 'homepage-events-band.tmpl' %}
-    {% include 'homepage-platform-band.tmpl' %}
-  </div>
-{% endblock %}
+{% block homepage_content %}
+  {% include 'homepage-tab-menu-band.tmpl' %}
+  {% include 'homepage-automate-band.tmpl' %}
+  {% include 'homepage-ecosystem-band.tmpl' %}
+  {% include 'homepage-community-band.tmpl' %}
+  {% include 'homepage-blog-band.tmpl' %}
+  {% include 'homepage-contribute-band.tmpl' %}
+  {% include 'homepage-bullhorn-band.tmpl' %}
+  {% include 'homepage-events-band.tmpl' %}
+  {% include 'homepage-platform-band.tmpl' %}
+{% endblock homepage_content %}

--- a/themes/ansible-community/sass/_hero-container.scss
+++ b/themes/ansible-community/sass/_hero-container.scss
@@ -1,7 +1,6 @@
 .hero-container {
-  max-width: 100%;
-  padding-left: 2rem;
-  padding-right: 2rem;
+  padding: 0 13rem;
+  margin: 0 -13rem;
   background-image: url(../images/unsplash.jpg);
   background-size: 100%;
   background-color: $pool;

--- a/themes/ansible-community/sass/_homepage-automate-band.scss
+++ b/themes/ansible-community/sass/_homepage-automate-band.scss
@@ -1,5 +1,4 @@
 .homepage-automate-band {
-  padding: 2rem;
   background-color: $white;
 }
 

--- a/themes/ansible-community/sass/_homepage-blog-band.scss
+++ b/themes/ansible-community/sass/_homepage-blog-band.scss
@@ -1,5 +1,4 @@
 .homepage-blog-band {
-  padding: 2rem;
   background-color: $grey94;
   grid-column: span 3;
   display: grid;

--- a/themes/ansible-community/sass/_homepage-body-spacer.scss
+++ b/themes/ansible-community/sass/_homepage-body-spacer.scss
@@ -1,0 +1,4 @@
+.homepage-body-spacer {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}

--- a/themes/ansible-community/sass/_homepage-body.scss
+++ b/themes/ansible-community/sass/_homepage-body.scss
@@ -1,0 +1,4 @@
+.homepage-body {
+  padding: 4rem 13rem;
+  margin: 0 -13rem;
+}

--- a/themes/ansible-community/sass/_homepage-bullhorn-band.scss
+++ b/themes/ansible-community/sass/_homepage-bullhorn-band.scss
@@ -1,8 +1,6 @@
 .homepage-bullhorn-band {
   margin-top: 0;
   background-color: $pool;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
   color: $black;
 }
 

--- a/themes/ansible-community/sass/_homepage-community-band.scss
+++ b/themes/ansible-community/sass/_homepage-community-band.scss
@@ -1,5 +1,4 @@
 .homepage-community-band {
-  padding: 2rem;
   background-color: $white;
 }
 

--- a/themes/ansible-community/sass/_homepage-container.scss
+++ b/themes/ansible-community/sass/_homepage-container.scss
@@ -1,5 +1,3 @@
 .homepage-container {
-  max-width: fit-content;
-  padding-left: 13rem;
-  padding-right: 13rem;
+  padding: 0 13rem;
 }

--- a/themes/ansible-community/sass/_homepage-contribute-band.scss
+++ b/themes/ansible-community/sass/_homepage-contribute-band.scss
@@ -1,5 +1,4 @@
 .homepage-contribute-band {
-  padding: 2rem;
   background-color: $white;
 }
 

--- a/themes/ansible-community/sass/_homepage-ecosystem-band.scss
+++ b/themes/ansible-community/sass/_homepage-ecosystem-band.scss
@@ -1,5 +1,4 @@
 .homepage-ecosystem-band {
-  padding: 1rem;
   background-color: $grey94;
   gap: 2rem;
 }

--- a/themes/ansible-community/sass/_homepage-events-band.scss
+++ b/themes/ansible-community/sass/_homepage-events-band.scss
@@ -1,8 +1,6 @@
 .homepage-events-band {
   margin-top: 0;
   background-color: $white;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
   text-align: left;
 }
 

--- a/themes/ansible-community/sass/_homepage-platform-band.scss
+++ b/themes/ansible-community/sass/_homepage-platform-band.scss
@@ -1,6 +1,5 @@
 .homepage-platform-band {
   background-color: $grey94;
-  padding: 4rem;
   font-size: 1rem;
 }
 

--- a/themes/ansible-community/sass/_homepage-tab-menu-band.scss
+++ b/themes/ansible-community/sass/_homepage-tab-menu-band.scss
@@ -1,5 +1,7 @@
 .homepage-tab-menu-band {
   margin-top: 0;
+  padding-top: 0;
+  padding-bottom: 0;
   background-color: $grey94;
   display: grid;
   grid-template-columns: repeat(5 1fr);

--- a/themes/ansible-community/sass/main.scss
+++ b/themes/ansible-community/sass/main.scss
@@ -4,8 +4,9 @@
 @import "nav-bar";
 @import "get-started-nav";
 @import "font-awesome";
-@import "hero-container";
 @import "homepage-container";
+@import "hero-container";
+@import "homepage-body";
 @import "homepage-section-title";
 @import "homepage-back-to-top";
 @import "homepage-get-started";

--- a/themes/ansible-community/templates/base.tmpl
+++ b/themes/ansible-community/templates/base.tmpl
@@ -13,12 +13,20 @@
 <a href="#content" class="sr-only sr-only-focusable">{{ messages("Skip to main content") }}</a>
 
 {% if permalink == '/' %}
-  {% block hero_content %}{% endblock %}
-  {% else %}
-  {% include 'base_nav.tmpl' %}
+<div class="homepage-container" id="content" role="main">
+    {% block hero_content %}{% endblock %}
+    <div class="body-content">
+        <!--Body content-->
+        {{ template_hooks['page_header']() }}
+        {% block homepage_content %}{% endblock homepage_content %}
+        <!--End of body content-->
+    </div>
+</div>
 {% endif %}
 
-<div {% if permalink == '/' %}class="homepage-container"{% else %}class="container"{% endif %} id="content" role="main">
+{% if permalink != '/' %}
+{% include 'base_nav.tmpl' %}
+<div class="container" id="content" role="main">
     <div class="body-content">
         <!--Body content-->
         {{ template_hooks['page_header']() }}
@@ -27,6 +35,7 @@
         <!--End of body content-->
     </div>
 </div>
+{% endif %}
 {{ footer.html_footer() }}
 
 {{ base.late_load_js() }}


### PR DESCRIPTION
Relates to issue #47

This PR makes some additional changes that follow up on https://github.com/ansible-community/community-website/commit/4a258e1c5ab432afb22273ecc8429f2a0f58a955

Firstly this PR modifies how the base template creates body containers. It creates a special ``homepage-container`` that wraps ``hero-container`` and ``body-content`` for the homepage. Secondary pages such as the blog continue to use the bootstrap ``container``.

The homepage-container sets `padding: 0 13rem;` so content on the page, including the nav and hero, is moved in on the left and right. The hero container and homepage-body class then set a padding and margin so that the background color of each band is full width while keeping the content from going full width.

The homepage-body class also includes 4rem of padding on the top and bottom so we can control that with a single call. The homepage menu (tabbed buttons) overrides that top and bottom padding and sets it to 0.

This PR also strips out padding declarations that are unnecessary and conflict with the desired classes.

Additionally the changes in this PR will make it much easier to control breakpoints and handle the responsive design.
