### PR TITLE
Design feedback on padding for sections and ecosystem

### DIFF
--- a/themes/ansible-community/sass/_homepage-body-spacer.scss
+++ b/themes/ansible-community/sass/_homepage-body-spacer.scss
@@ -1,4 +1,4 @@
 .homepage-body-spacer {
-  padding-top: 1rem;
-  padding-bottom: 1rem;
+  padding-top: 40px;
+  padding-bottom: 40px;
 }

--- a/themes/ansible-community/sass/_homepage-ecosystem-band.scss
+++ b/themes/ansible-community/sass/_homepage-ecosystem-band.scss
@@ -8,7 +8,7 @@
   height: 160px;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
   transition: 0.3s;
-  padding: 1rem;
+  padding: 24px;
   border-width: 1px;
   border-radius: 5px;
   background-color: $white;


### PR DESCRIPTION
Fixes issue #162 

- Set padding for each body section to 40px top and bottom.
- Set padding within ecosystem cards to 24px all around.