### PR TITLE
Change the way spacing works in the menu band

### DIFF
--- a/themes/ansible-community/sass/_homepage-tab-menu-band.scss
+++ b/themes/ansible-community/sass/_homepage-tab-menu-band.scss
@@ -14,7 +14,7 @@
 .tab-menu-row {
   display: flex;
   flex-direction: row;
-  justify-content: space-evenly;
+  justify-content: space-between;
 }
 
 .tab-menu-box {


### PR DESCRIPTION
@oraNod @tiyiprh this change tweaks the spacing in the middle nav menu.  I couldn't get the buttons all the same size _and_ get the text centered.  Let me know what you all think.

<img width="1561" alt="Screenshot 2023-09-27 at 4 43 54 PM" src="https://github.com/ansible-community/community-website/assets/9889020/05d46cd6-90b1-4fd7-8b7e-b837af382ec0">
