### PR TITLE
nowrap get started banner text

### DIFF
--- a/themes/ansible-community/sass/_homepage-banner-band.scss
+++ b/themes/ansible-community/sass/_homepage-banner-band.scss
@@ -49,6 +49,7 @@
     font-weight: 500;
     color: $white;
     text-decoration: none;
+    white-space: nowrap;
     &:hover {
       color: $pool !important;
     }


### PR DESCRIPTION
Prevent the "Get started with Ansible" text from wrapping. This keeps the anchor from resizing when moving the screen around.