### PR TITLE
Redundant link for platform url

### DIFF
--- a/data/homepage.yaml
+++ b/data/homepage.yaml
@@ -107,7 +107,7 @@ events:
 platform:
   main: Get enterprise engineering and support from Red Hat with a platform that can tackle any automation challenge.
   discover: Red Hat Ansible Automation Platform provides everything needed to create, execute, and manage automation in a single subscription. From execution environments to certified collections to automation analytics, discover the features and benefits of Ansible Automation Platform.
-  learn: Learn about Red Hat Ansible Automation Platform
+  learn: View more about Red Hat Ansible Automation Platform
   logo_alt: Red Hat Ansible Automation Platform
 ecosystem:
   section_icon: /assets/images/communities-cyan.svg

--- a/templates/homepage-banner-band.tmpl
+++ b/templates/homepage-banner-band.tmpl
@@ -21,7 +21,7 @@
           </div>
         </div>
         <div class="banner-platform-learn">
-          <a href="{{ homepage.links.platform.home }}">
+          <a href="#platform">
             <img class="banner-redhat-logo"
                  src="/images/redhat.svg"
                  alt="{{ homepage.banner.redhat_logo_alt }}"

--- a/themes/ansible-community/sass/_homepage-platform-band.scss
+++ b/themes/ansible-community/sass/_homepage-platform-band.scss
@@ -38,7 +38,7 @@
     .btn {
       border-radius: 2px;
       padding: 14px;
-      width: fit-content;
+      width: 100%;
     }
   }
 }
@@ -55,10 +55,5 @@
   .platform-box-right {
     grid-column-start: initial;
     grid-column-end: initial;
-    .platform-learn-more {
-      .btn {
-        width: 100%;
-      }
-    }
   }
 }


### PR DESCRIPTION
issue #247 

This PR reverts changes applied in https://github.com/ansible-community/community-website/pull/237

The justification for the change is that the platform url is redundant on the homepage in violation of accessibility guidelines. Now the anchor on the banner directs to the platform section at the bottom of the homepage, which then links to the platform homepage.

Some additional minor changes to visually improve the anchor in the platform section and ensure that wording in both anchors is unique.