### PR TITLE
make fa icons consistent

### DIFF
--- a/templates/homepage-back-to-top.tmpl
+++ b/templates/homepage-back-to-top.tmpl
@@ -1,5 +1,5 @@
 <div class="width-12-12 width-12-12-m">
   <div class="back-to-top">
-    <a href="#top">{{ homepage.labels.back_to_top }}&ensp;<i class="fa fa-arrow-up" aria-hidden="true"></i></a>
+    <a href="#top">{{ homepage.labels.back_to_top }}&ensp;<i class="fa fa-arrow-up" aria-hidden="true" /></a>
   </div>
 </div>

--- a/templates/homepage-banner-band.tmpl
+++ b/templates/homepage-banner-band.tmpl
@@ -26,7 +26,7 @@
                alt="{{ homepage.banner.redhat_logo_alt }}"
                width="20"
                height="20" />
-          <a href="#platform">{{ homepage.banner.platform_learn }}&ensp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a>
+          <a href="#platform">{{ homepage.banner.platform_learn }}&ensp;<i class="fa fa-arrow-right" aria-hidden="true" /></a>
         </div>
       </div>
       <div class="banner-welcome-image">

--- a/templates/homepage-blog-band.tmpl
+++ b/templates/homepage-blog-band.tmpl
@@ -8,7 +8,7 @@
            height="40" />
       <h2>{{ homepage.blog.title }}</h2>
       <div class="section-view-more">
-        <a href="{{ homepage.blog.url }}">{{ homepage.labels.view_more }}&ensp;<i class="fa fa-arrow-right"></i></a>
+        <a href="{{ homepage.blog.url }}">{{ homepage.labels.view_more }}&ensp;<i class="fa fa-arrow-right" aria-hidden="true" /></a>
       </div>
     </div>
     <p>{{ homepage.blog.intro }}</p>

--- a/templates/homepage-ecosystem-band.tmpl
+++ b/templates/homepage-ecosystem-band.tmpl
@@ -9,7 +9,7 @@
            height="40" />
       <h2>{{ homepage.ecosystem.title }}</h2>
       <div class="section-view-more">
-        <a href="{{ homepage.ecosystem.url }}">{{ homepage.labels.view_more }}&ensp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a>
+        <a href="{{ homepage.ecosystem.url }}">{{ homepage.labels.view_more }}&ensp;<i class="fa fa-arrow-right" aria-hidden="true" /></a>
       </div>
     </div>
     <p>{{ homepage.ecosystem.intro }}</p>
@@ -19,7 +19,7 @@
       <div class="ecosystem-content">
         <h3>{{ item.heading }}</h3>
         <p>{{ item.description }}</p>
-        <a href="{{ item.link }}">{{ homepage.labels.learn_more }}&ensp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a>
+        <a href="{{ item.link }}">{{ homepage.labels.learn_more }}&ensp;<i class="fa fa-arrow-right" aria-hidden="true" /></a>
       </div>
       <img class="ecosystem-logo"
            src="/images/{{ item.logo }}"

--- a/templates/homepage-events-band.tmpl
+++ b/templates/homepage-events-band.tmpl
@@ -8,7 +8,7 @@
            height="40" />
       <h2>{{ homepage.events.title }}</h2>
       <div class="section-view-more">
-        <a href="{{ homepage.events.url }}">{{ homepage.labels.view_more }}&ensp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a>
+        <a href="{{ homepage.events.url }}">{{ homepage.labels.view_more }}&ensp;<i class="fa fa-arrow-right" aria-hidden="true" /></a>
       </div>
     </div>
     <p>{{ homepage.events.intro }}</p>


### PR DESCRIPTION
Use consistent closing tags with fa icons and add `aria-hidden="true"` so the icons are ignored by assistive technology.