### PR TITLE
change platform logo url anchor

### DIFF
--- a/data/homepage.yaml
+++ b/data/homepage.yaml
@@ -174,3 +174,4 @@ links:
     get_started_url: https://docs.ansible.com/ansible/latest/getting_started/index.html
   platform:
     home: https://www.redhat.com/en/technologies/management/ansible
+    use_cases: https://www.redhat.com/en/technologies/management/ansible/use-cases

--- a/templates/homepage-platform-band.tmpl
+++ b/templates/homepage-platform-band.tmpl
@@ -3,7 +3,7 @@
   <div class="width-12-12 width-12-12-m">
     <div class="platform-row">
       <div class="platform-box-left">
-        <a href="{{ homepage.links.platform.home }}">
+        <a href="{{ homepage.links.platform.use_cases }}">
           <img src="/images/platform.svg"
                alt="{{ homepage.platform.logo_alt }}"
                width="500"


### PR DESCRIPTION
Avoid redundant url in adjacent anchors in the platform section.