### PR TITLE
Switch supported for sponsored

### DIFF
--- a/themes/ansible-community/templates/base_footer.tmpl
+++ b/themes/ansible-community/templates/base_footer.tmpl
@@ -18,11 +18,11 @@
         </ul>
       </div>
       <div class="footer-right">
-        <span class="redhat">Supported by</span>
+        <span class="redhat">Sponsored by</span>
         <span class="redhat-logo">
           <a href="{{ homepage.links.platform.home }}" target="_blank">
             <img src="/assets/images/redhat_reversed.svg"
-                 alt="Red Hat logo. The Ansible community is supported by Red Hat."
+                 alt="Red Hat logo."
                  width="96"
                  height="28" />
           </a>


### PR DESCRIPTION
"Supported" is a tricky word - in some cases it may lead people to think they can *expect* support, rather than the meaning here that Red Hat supports us in doing our work.

To avoid this, we should use "sponsored" (which is what other projects use, eg see the footer for fedoraproject.org).

/cc @wbentley15