### PR TITLE
Add a dockerfile for the community website

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ WORKDIR /community-website
 
 # Install Nikola and build the community website
 RUN pip install -r requirements.in -c requirements.txt
-RUN nikola build
+RUN nikola build --strict
 
-# Host the community website on an nginx web server
+# Host the community website on a caddy web server
 FROM registry.fedoraproject.org/fedora:38
 EXPOSE 8080
 RUN dnf install --setopt=install_weak_deps=False --best -y caddy && dnf clean all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Build the community website with Nikola
+FROM python:3.11 AS builder
+
+# Add the contents of this repository to the working directory
+ADD . /community-website
+
+# Set the working directory
+WORKDIR /community-website
+
+# Install Nikola and build the community website
+RUN pip install -r requirements.in -c requirements.txt
+RUN nikola build
+
+# Host the community website on an nginx web server
+FROM registry.fedoraproject.org/fedora:38
+EXPOSE 8080
+RUN dnf install --setopt=install_weak_deps=False --best -y caddy && dnf clean all
+COPY --from=builder /community-website/output/ /var/www/html/
+CMD ["/usr/bin/caddy", "file-server", "--listen", ":8080", "--root", "/var/www/html/"]


### PR DESCRIPTION
This PR adds a dockerfile for building and deploying the community website. Additionally this PR updates CI so that the dockerfile is used to verify the build instead of the nikola build action.

As a follow up PR we can add a step to push the resulting image to a registry.