### PR TITLE
action to build and push the website image

### DIFF
--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -3,7 +3,7 @@ name: Build and publish the container image
 on:
   push:
     branches:
-      - "main"
+    - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -6,14 +6,15 @@ on:
     - main
   workflow_dispatch:
 
+env:
+  IMAGE_NAME: ansible-community/ansible-website
+  TAGS: latest
+  REGISTRY: ghcr.io
+  REGISTRY_USER: ${{ github.actor }}
+
 jobs:
   build_dockerfile:
     runs-on: ubuntu-20.04
-    env:
-      IMAGE_NAME: ansible-community/ansible-website
-      TAGS: latest
-      REGISTRY: ghcr.io
-      REGISTRY_USER: ${{ github.actor }}
     name: Build and publish the image
     steps:
     - name: Check out the website repository

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -1,0 +1,37 @@
+name: Build and publish the container image
+
+on:
+  push:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  build_dockerfile:
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: ansible-community/ansible-website
+      TAGS: latest
+      REGISTRY: ghcr.io
+      REGISTRY_USER: ${{ github.actor }}
+    name: 'Build and publish the image'
+    steps:
+    - name: Check out the website repository
+      uses: actions/checkout@v3
+    - name: Buildah build the website image
+      id: build_image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ env.IMAGE_NAME }}
+        tags: ${{ env.TAGS }}
+        containerfiles: |
+          ./Dockerfile
+    - name: Push the website image to ghcr.io
+      id: push_image
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build_image.outputs.image }}
+        tags: ${{ steps.build_image.outputs.tags }}
+        registry: ${{ env.REGISTRY }}
+        username: ${{ env.REGISTRY_USER }}
+        password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -14,7 +14,7 @@ jobs:
       TAGS: latest
       REGISTRY: ghcr.io
       REGISTRY_USER: ${{ github.actor }}
-    name: 'Build and publish the image'
+    name: Build and publish the image
     steps:
     - name: Check out the website repository
       uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds a workflow to build and push the website image to the community packages at https://github.com/orgs/ansible-community/packages

We can then create an image stream from the published image.