### PR TITLE
dependabot python requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
     labels:
       - "dockerfile"
       - "dependencies"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "pip"
+      - "dependencies"


### PR DESCRIPTION
Follows up on https://github.com/ansible-community/community-website/pull/298 and includes dependabot config for python requirements