### PR TITLE
make navigation colors consistent

### DIFF
--- a/themes/ansible-community/sass/_nav-bar.scss
+++ b/themes/ansible-community/sass/_nav-bar.scss
@@ -14,7 +14,7 @@
     color: $black;
     font-size: $font-lg;
     &:hover {
-      color: $cyan !important;
+      color: $white !important;
     }
   }
   @media screen and (max-width: 992px) {
@@ -62,7 +62,7 @@ Set overriding homepage properties in the hero-container class.
 .nav-link-color {
   color: $black !important;
   &:hover {
-    color: $cyan !important;
+    color: $white !important;
   }
 }
 


### PR DESCRIPTION
There currently is a inconsistency between the home page and sub page navigation. The secondary pages have a different hover color. I've made them match the home page (for user consistency)