### PR TITLE
Revert python 3.12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      # Avoid python version upgrade to 3.12+
+      # until nikola adds support https://github.com/getnikola/nikola/issues/3719
+      - dependency-name: "python*"
     labels:
       - "dockerfile"
       - "dependencies"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the community website with Nikola
-FROM python:3.12 AS builder
+FROM python:3.11 AS builder
 
 # Add the contents of this repository to the working directory
 ADD . /community-website


### PR DESCRIPTION
This PR reverts the dependabot commit that upgrades the python version in the dockerfile to 3.12. Nikola does not yet support 3.12 and the build fails with the same error mentioned here: https://github.com/getnikola/nikola/issues/3719