### PR TITLE
update resources drop down menu

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -162,10 +162,8 @@ NAVIGATION_ALT_LINKS = {
         (
           (
             ("/how-ansible-works/", "How Ansible works", ""),
-            ("/ansible-community-training/", "Ansible community training", ""),
             ("/ecosystem/", "Ansible ecosystem", ""),
-            ("/awx/", "Ansible AWX", ""),
-            ("/galaxy/", "Ansible Galaxy", ""),
+            ("/ansible-community-training/", "Ansible community training", ""),
             ("/contact-us/", "Contact us", ""),
           ),
           "Resources", ""


### PR DESCRIPTION
This PR updates the drop-down for the "Resources" menu item in the masthead navigation. The AWX project and Galaxy secondary pages are accessible from the ecosystem page and do not really need to be listed individually in the drop-down.