### PR TITLE
Bullhorn subscribe by email

### DIFF
--- a/data/homepage.yaml
+++ b/data/homepage.yaml
@@ -56,7 +56,8 @@ bullhorn:
   title: Subscribe to the Bullhorn
   about: The Bullhorn is a weekly newsletter full of Ansible Community news and updates.
   forum_text: Read the latest edition
-  subscribe: Subscribe
+  subscribe: Subscribe by email
+  mailchimp_link: https://bit.ly/subscribe-bullhorn
   forum_link: https://forum.ansible.com/c/news/bullhorn/17
   forum_feed: https://forum.ansible.com/c/news/bullhorn/17.rss
 events:

--- a/templates/homepage-bullhorn-band.tmpl
+++ b/templates/homepage-bullhorn-band.tmpl
@@ -16,7 +16,7 @@
       <a class="homepage-anchor"
          href="{{ homepage.bullhorn.mailchimp_link }}"
          role="button"
-         target="_blank">{{ homepage.bullhorn.subscribe }}&ensp;<i class="fab fa-mailchimp" aria-hidden="true" /></a>
+         target="_blank">{{ homepage.bullhorn.subscribe }}</a>
     </div>
   </div>
 </div>

--- a/templates/homepage-bullhorn-band.tmpl
+++ b/templates/homepage-bullhorn-band.tmpl
@@ -14,9 +14,9 @@
          role="button"
          target="_blank">{{ homepage.bullhorn.forum_text }}</a>
       <a class="homepage-anchor"
-         href="{{ homepage.bullhorn.forum_feed }}"
+         href="{{ homepage.bullhorn.mailchimp_link }}"
          role="button"
-         target="_blank">{{ homepage.bullhorn.subscribe }}&ensp;<i class="fa fa-rss" aria-hidden="true" /></a>
+         target="_blank">{{ homepage.bullhorn.subscribe }}&ensp;<i class="fab fa-mailchimp" aria-hidden="true" /></a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Resolves issue #351 

This PR:

- Removes the link on the homepage to the forum RSS feed for bullhorn posts.
- Adds a link on the homepage to the mailchimp subscription form: https://ansible.us19.list-manage.com/subscribe?u=56d874e027110e35dea0e03c1&id=d6635f5420
- Changes the text of the subscribe button on the homepage to "Subscribe by email"
- Changes the icon on the subscribe button from RSS feed to Mailchimp.

![image](https://github.com/ansible-community/community-website/assets/32749632/adfb41ff-371e-493d-9816-8bf30e2f1124)

Mobile:

![image](https://github.com/ansible-community/community-website/assets/32749632/bcf9ac78-fcf6-436f-90e0-d1e75ae84d4b)
