### PR TITLE
Clear separation between entries on the blog index

### DIFF
--- a/themes/ansible-community/sass/_ansible-content.scss
+++ b/themes/ansible-community/sass/_ansible-content.scss
@@ -31,6 +31,10 @@
     margin-left: auto;
     margin-right: auto;
   }
+  hr {
+    border: 2px solid $cyan;
+    border-radius: 2px;
+  }
 }
 
 /** Page headers **/

--- a/themes/ansible-community/templates/index.tmpl
+++ b/themes/ansible-community/templates/index.tmpl
@@ -21,7 +21,7 @@
   {% if page_links %}
     {{ pagination.page_navigation(current_page, page_links, prevlink, nextlink, prev_next_links_reversed) }}
   {% endif %}
-  <div class="postindex ansible-posts">
+  <div class="postindex ansible-content">
     {% for post in posts %}
       <article class="h-entry post-{{ post.meta("type") }}"
                itemscope="itemscope"
@@ -71,6 +71,9 @@
             {% endif %}
           </div>
       </article>
+      <br/>
+      <hr/>
+      <br/>
     {% endfor %}
   </div>
   {{ helper.html_pager() }}


### PR DESCRIPTION
Fixes #356 

This PR:

- Updates the post index template to use the correct style class.
- Adds line breaks and a horizontal rule to the post index template so that there is more visual space between posts as well as a line separating each post entry.
- Adds styling to the horizontal rule.

![image](https://github.com/ansible-community/community-website/assets/32749632/3b03fe20-d556-44dd-98cf-6a4857c6f670)

Note that the breaks and horizontal rule apply to the end of every blog post in the index, including the last one on the page for example:

![image](https://github.com/ansible-community/community-website/assets/32749632/d07c0297-7d0e-4e28-bc90-e68e6c1fadd9)
