### PR TITLE
fix home page resonsponsive issues on mobile

### DIFF
--- a/themes/ansible-community/sass/_homepage-ansible-band.scss
+++ b/themes/ansible-community/sass/_homepage-ansible-band.scss
@@ -17,11 +17,8 @@
 
 .ansible-image {
   display: flex;
-  width: 30rem;
+
   img {
-    @media screen and (max-width: 992px) {
-      width: 20rem;
-    }
     @media screen and (max-width: 768px) {
       display: none;
     }

--- a/themes/ansible-community/sass/_homepage-contribute-band.scss
+++ b/themes/ansible-community/sass/_homepage-contribute-band.scss
@@ -33,13 +33,12 @@
   }
 }
 
+
+
 .contribute-bull {
   display: flex;
-  width: 30rem;
   img {
-    @media screen and (max-width: 1170px) {
-      width: 15rem;
-    }
+
     @media screen and (max-width: 768px) {
       display: none;
     }

--- a/themes/ansible-community/sass/_homepage-ecosystem-band.scss
+++ b/themes/ansible-community/sass/_homepage-ecosystem-band.scss
@@ -1,6 +1,5 @@
 .homepage-ecosystem-band {
   background-color: $grey94;
-  gap: 2rem;
 }
 
 .ecosystem-card {


### PR DESCRIPTION
@oraNod - the horizontal scroll issue seems to be caused by the fixed image widths on the large view. if we remove this, the images are allowed the scale (which as a side benefit, makes the text much more readable as the page size gets smaller). Even though the images are set not to display, the browser still doesn't want to clear widths.

My recommendation is to remove the forced fixed widths and let the browser scale the images.

Additionally, I removed the extra gap spacing on the ecosystem grid (this too was causing a little horizontal scroll).