### PR TITLE
update blog homepage to show latest posts

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -4,5 +4,5 @@ slug: index
 type: text
 template: homepage.tmpl
 ---
-{{% post-list stop=2 tags=community template=homepage-blogs.tmpl %}}{{% /post-list %}}
+{{% post-list stop=2 template=homepage-blogs.tmpl %}}{{% /post-list %}}
 {{% post-list stop=1 tags=news template=homepage-blogs.tmpl %}}{{% /post-list %}}

--- a/templates/homepage-blogs.tmpl
+++ b/templates/homepage-blogs.tmpl
@@ -10,7 +10,11 @@
           by <a href="/authors/{{ post.author() | slugify() }}">{{ post.author() }}</a> - {{ post.date.strftime("%_d %b '%y") }}
         </p>
       </div>
-      {{ post.text(teaser_only=True) }}
+      {% if "news" in post.tags %}
+        {{ post.text(teaser_only=True) }}
+      {% else %}
+        {{ post.description() }}
+      {% endif %}
     </div>
   {% endfor %}
 {% endif %}


### PR DESCRIPTION
This PR:

- Removes the "community" tag from the post list filter in the index page so that the two most recent blog posts show up on the homepage blog band.
- Makes it so that the post description is used as the display text on the homepage. This removes the need for manually specifying teaser content with HTML comments in blog posts.

This will require authors to add a description to each post that summarizes the content. We should add details about how the description is shown on the homepage to the README or somewhere so that it's clear how this works.