### PR TITLE
enable spelling checks on blog posts

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-skip = *.svg,./cache,./output,./venv,./plugins,conf.py,./posts,./blog-archive,./bullhorn,clipboard.min.js
+skip = *.svg,./cache,./output,./venv,./plugins,conf.py,./blog-archive,./bullhorn,clipboard.min.js
 count =
 check-filenames = true
 quiet-level = 3


### PR DESCRIPTION
First we need to merge this PR so that we don't try to spell check the bullhorn archive: https://github.com/ansible-community/community-website/pull/407