### PR TITLE
fix tab menu alignment issue

### DIFF
--- a/themes/ansible-community/sass/_homepage-clickable.scss
+++ b/themes/ansible-community/sass/_homepage-clickable.scss
@@ -24,27 +24,6 @@
   white-space: inherit;
 }
 
-/* tabs in the secondary menu */
-.tab-menu-anchor {
-  display: flex;
-  padding: 1.75rem;
-  align-items: center;
-  justify-content: center;
-  font-size: $font-lg;
-  img {
-    float: left;
-    width: auto;
-    height: 2.5rem;
-  }
-  p {
-    white-space: nowrap;
-  }
-  &:hover {
-    background-color: $white;
-    color: $navy;
-  }
-}
-
 /* controls text elements next to
    anchors, such as fa icons */
 .homepage-link {

--- a/themes/ansible-community/sass/_homepage-tab-menu-band.scss
+++ b/themes/ansible-community/sass/_homepage-tab-menu-band.scss
@@ -20,3 +20,21 @@
     color: $cyan;
   }
 }
+
+.tab-menu-anchor {
+  display: flex;
+  padding: 1.75rem;
+  justify-content: center;
+  font-size: $font-lg;
+  img {
+    float: left;
+    margin-right: 0.25rem;
+  }
+  p {
+    white-space: nowrap;
+  }
+  &:hover {
+    background-color: $white;
+    color: $navy;
+  }
+}

--- a/themes/ansible-community/sass/_homepage-tab-menu-band.scss
+++ b/themes/ansible-community/sass/_homepage-tab-menu-band.scss
@@ -5,7 +5,6 @@
   background-color: $grey94;
   display: grid;
   grid-template-columns: repeat(5 1fr);
-  gap: 20px;
   @media screen and (max-width: 992px) {
     display: none;
   }
@@ -23,9 +22,10 @@
 
 .tab-menu-anchor {
   display: flex;
-  padding: 1.75rem;
+  padding: 1.75rem 1.75rem 1rem 1.75rem;
   justify-content: center;
   font-size: $font-lg;
+  line-height: 40px;
   img {
     float: left;
     margin-right: 0.25rem;


### PR DESCRIPTION
This PR moves the tab menu anchor class to the tab menu band scss file because it's confusing otherwise. The tab menu anchor class is only used in one place anyway.

This PR also adjusts the tab menu anchors so that the icon and the text are better aligned with one another.