### PR TITLE
cp all but robots to readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,4 +14,5 @@ build:
     - python -m pip install --upgrade -r ./requirements.in -c ./requirements.txt
     - nikola build
     - mkdir -p _readthedocs/html/
-    - cp -r output/!(robots.txt) _readthedocs/html/
+    - cp -r output/* _readthedocs/html/
+    - rm _readthedocs/html/robots.txt


### PR DESCRIPTION
Relates to  #385

This PR updates the readthdocs config so that everything except for the nikola-generated robots.txt file is copied to the target html directory. This ensures that the RTD robots.txt file is used and the project settings take effect, namely that the RTD project is hidden.