### PR TITLE
Remove disallow from robots.txt

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1079,7 +1079,7 @@ STRIP_INDEXES = True
 # from indexing and other robotic spidering. * is supported. Will only be effective
 # if SITE_URL points to server root. The list is used to exclude resources from
 # /robots.txt and /sitemap.xml, and to inform search engines about /sitemapindex.xml.
-ROBOTS_EXCLUSIONS = ["*"]
+#ROBOTS_EXCLUSIONS = ["*"]
 
 # Instead of putting files in <slug>.html, put them in <slug>/index.html.
 # No web server configuration is required. Also enables STRIP_INDEXES.


### PR DESCRIPTION
Resolves #385 and relates to #424

Need to remove the disallow bit from the nikola-generated robots.txt file to avoid issues with indexing.