### PR TITLE
restore keys in homepage data

### DIFF
--- a/data/homepage.yaml
+++ b/data/homepage.yaml
@@ -68,6 +68,36 @@ events:
   section_icon: /assets/images/calendar-cyan.svg
   icon_alt: Ansible community event icon
   title: Events
+  intro: Share and learn about automation at Ansible events, in person or online.
+  url: https://forum.ansible.com/c/events/
+  view_calendar: View more
+  event_descriptions:
+    # This section contains various event descriptions.
+    # Copy and paste these descriptions as needed when updating event details.
+    # Changing below does not change text on the homepage. The value of the "events_list.<event>.description" key is used on the homepage.
+    community_day: Get together with a broad community of users, contributors, entusiasts, IT professionals and more to learn and share about Ansible automation.
+    contributor_summit: Interact with the Ansible contributor community and Ansible at Red Hat engineers to improve collaboration and possibly do some hacking.
+  events_list:
+    event_one:
+      name: Configuration Management Camp
+      # If the event is community day or contributor summit, you can copy the description from event_descriptions.
+      # Important: To prevent reflow and text wrapping issues on the homepage descriptions should be approximately 100 characters long.
+      description: Configuration Management Camp is the event for technologists interested in open source infrastructure automation and related topics.
+      date: February 5 to 7, 2024
+      location: Ghent, Belgium
+      image: cfgmgmtcamp-logo.png
+      alt: CfgMgmtCamp logo
+      link: https://forum.ansible.com/t/config-management-camp/91
+    event_two:
+      name: Ansible Minneapolis Meetup
+      # If the event is community day or contributor summit, you can copy the description from event_descriptions.
+      # Important: To prevent reflow and text wrapping issues on the homepage descriptions should be approximately 100 characters long.
+      description: Join a group of systems engineers and DevOps folks who want to Ansible all the things. Learn more and share your Ansible knowledge.
+      date: January 18, 2024
+      location: Minneapolis, MN, USA
+      image: ansible-meetup.svg
+      alt: Ansible meetup logo
+      link: https://forum.ansible.com/t/ansible-minneapolis-meetup-topic-tba-2024-01-18/1863
 platform:
   main: Get enterprise engineering and support from Red Hat with a platform that can tackle any automation challenge.
   discover: Red Hat Ansible Automation Platform provides everything needed to create, execute, and manage automation in a single subscription. From execution environments to certified collections to automation analytics, discover the features and benefits of Ansible Automation Platform.
@@ -104,6 +134,12 @@ ecosystem:
       link: https://ansible.readthedocs.io/projects/rulebook/
       logo: project-logos/eda.svg
       alt: Event-Driven Ansible project logo
+blog:
+  section_icon: /assets/images/blog-cyan.svg
+  icon_alt: Ansible community blog icon
+  title: Blog
+  intro: Check out some recent blog posts from the Ansible community.
+  url: /blog/
 contribute:
   section_icon: /assets/images/collaboration-cyan.svg
   icon_alt: Ansible community contributor icon


### PR DESCRIPTION
This PR restores keys in the homepage data that are required by the corresponding templates. The templates were not removed so the keys should not be either.