### PR TITLE
update site url in nikola conf

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
   commands:
     - python -m pip install --upgrade --no-cache-dir pip setuptools
     - python -m pip install --upgrade -r ./requirements.in -c ./requirements.txt
-    - nikola build
+    - nikola build --conf=dev.conf.py
     - mkdir -p _readthedocs/html/
     - cp -r output/* _readthedocs/html/
     - rm _readthedocs/html/robots.txt

--- a/conf.py
+++ b/conf.py
@@ -20,7 +20,7 @@ BLOG_AUTHOR = "Ansible Community, et al"  # (translatable)
 BLOG_TITLE = "Ansible Community"  # (translatable)
 # This is the main URL for your site. It will be used
 # in a prominent link. Don't forget the protocol (http/https)!
-SITE_URL = "https://ansible-community-website.readthedocs.io/"
+SITE_URL = "https://ansible.com/"
 # This is the URL where Nikola's output will be deployed.
 # If not set, defaults to SITE_URL
 # BASE_URL = "https://ansible.community/"

--- a/dev.conf.py
+++ b/dev.conf.py
@@ -1,0 +1,2 @@
+from conf import *
+SITE_URL = "https://ansible-community-website.readthedocs.io/"


### PR DESCRIPTION
Resolves #426 

* Add a dev configuration file that sets the site url to the readthedocs location. This ensures that the production url does not leak into the dev site.
* Update readthedocs configuration to use the dev conf file.