### PR TITLE
Update some controller links and remove stale links

### DIFF
--- a/.codespellignorelines
+++ b/.codespellignorelines
@@ -1,4 +1,5 @@
-# The following line comes from pages/faq.md and should be updated pending https://github.com/ansible/awx-logos/issues/12
+# The following lines come from pages/faq.md and should be updated pending https://github.com/ansible/awx-logos/issues/12
 For more details, consult the [AWX trademark guidelines](https://github.com/ansible/awx-logos/blob/master/TRADEMARKS.md).
+Be sure to read the [AWX trademark guidelines](https://github.com/ansible/awx-logos/blob/master/TRADEMARKS.md) for more information.
 # The following line comes from data/ecosystem.yaml
 als:

--- a/conf.py
+++ b/conf.py
@@ -161,16 +161,20 @@ NAVIGATION_ALT_LINKS = {
         ),
         (
           (
+            ("/mission-statement/", "Our mission statement", ""),
             ("/how-ansible-works/", "How Ansible works", ""),
             ("/ecosystem/", "Ansible ecosystem", ""),
+            ("/awx/", "AWX", ""),
+            ("/galaxy/", "Galaxy", ""),
+            ("/faq/", "Frequently asked questions", ""),
             ("/ansible-community-training/", "Ansible community training", ""),
-            ("/mission-statement/", "Our mission statement", ""),
             ("/contact-us/", "Contact us", ""),
           ),
           "Resources", ""
         ),
-        ("https://forum.ansible.com/", "Ansible community forum", ""),
+        ("https://forum.ansible.com/", "Forum", ""),
         ("https://docs.ansible.com/", "Documentation", ""),
+        ("https://www.redhat.com/en/technologies/management/ansible/", "Ansible Automation Platform", ""),
     )
 }
 

--- a/data/homepage.yaml
+++ b/data/homepage.yaml
@@ -92,6 +92,18 @@ ecosystem:
       link: https://ansible.readthedocs.io/projects/awx/
       logo: project-logos/awx.svg
       alt: AWX project logo
+    runner:
+      heading: Ansible Runner
+      description: An interface abstraction to Ansible that offers reliable and consistent task execution.
+      link: https://ansible.readthedocs.io/projects/runner/
+      logo: project-logos/runner.svg
+      alt: Ansible Runner project logo
+    builder:
+      heading: Ansible Builder
+      description: Tooling to configure and build customized Ansible control nodes in container images.
+      link: https://ansible.readthedocs.io/projects/builder/
+      logo: project-logos/builder.svg
+      alt: Ansible Builder project logo
     eda:
       heading: Event-Driven Ansible
       description: Subscribe to event sources to scale automation and deliver more efficient IT operations.

--- a/data/homepage.yaml
+++ b/data/homepage.yaml
@@ -68,6 +68,36 @@ events:
   section_icon: /assets/images/calendar-cyan.svg
   icon_alt: Ansible community event icon
   title: Events
+  intro: Share and learn about automation at Ansible events, in person or online.
+  url: https://forum.ansible.com/c/events/
+  view_calendar: View more
+  event_descriptions:
+    # This section contains various event descriptions.
+    # Copy and paste these descriptions as needed when updating event details.
+    # Changing below does not change text on the homepage. The value of the "events_list.<event>.description" key is used on the homepage.
+    community_day: Get together with a broad community of users, contributors, entusiasts, IT professionals and more to learn and share about Ansible automation.
+    contributor_summit: Interact with the Ansible contributor community and Ansible at Red Hat engineers to improve collaboration and possibly do some hacking.
+  events_list:
+    event_one:
+      name: Configuration Management Camp
+      # If the event is community day or contributor summit, you can copy the description from event_descriptions.
+      # Important: To prevent reflow and text wrapping issues on the homepage descriptions should be approximately 100 characters long.
+      description: Configuration Management Camp is the event for technologists interested in open source infrastructure automation and related topics.
+      date: February 5 to 7, 2024
+      location: Ghent, Belgium
+      image: cfgmgmtcamp-logo.png
+      alt: CfgMgmtCamp logo
+      link: https://forum.ansible.com/t/config-management-camp/91
+    event_two:
+      name: Ansible Minneapolis Meetup
+      # If the event is community day or contributor summit, you can copy the description from event_descriptions.
+      # Important: To prevent reflow and text wrapping issues on the homepage descriptions should be approximately 100 characters long.
+      description: Join a group of systems engineers and DevOps folks who want to Ansible all the things. Learn more and share your Ansible knowledge.
+      date: January 18, 2024
+      location: Minneapolis, MN, USA
+      image: ansible-meetup.svg
+      alt: Ansible meetup logo
+      link: https://forum.ansible.com/t/ansible-minneapolis-meetup-topic-tba-2024-01-18/1863
 platform:
   main: Get enterprise engineering and support from Red Hat with a platform that can tackle any automation challenge.
   discover: Red Hat Ansible Automation Platform provides everything needed to create, execute, and manage automation in a single subscription. From execution environments to certified collections to automation analytics, discover the features and benefits of Ansible Automation Platform.
@@ -110,6 +140,12 @@ ecosystem:
       link: https://ansible.readthedocs.io/projects/rulebook/
       logo: project-logos/eda.svg
       alt: Event-Driven Ansible project logo
+blog:
+  section_icon: /assets/images/blog-cyan.svg
+  icon_alt: Ansible community blog icon
+  title: Blog
+  intro: Check out some recent blog posts from the Ansible community.
+  url: /blog/
 contribute:
   section_icon: /assets/images/collaboration-cyan.svg
   icon_alt: Ansible community contributor icon

--- a/data/homepage.yaml
+++ b/data/homepage.yaml
@@ -11,6 +11,10 @@ ansible:
   section_icon: /assets/images/automation-cyan.svg
   icon_alt: Ansible automation icon
   image_alt: Ansible community collaboration
+  mission: Learn more about our mission
+  mission_url: link://slug/mission-statement
+  join: Join the Ansible community
+  join_url: https://docs.ansible.com/community.html
   title: What is Ansible?
   intro: Ansible is open-source technology that can perform virtually any IT task and remove complexity from workflows.
   top_section:
@@ -64,36 +68,6 @@ events:
   section_icon: /assets/images/calendar-cyan.svg
   icon_alt: Ansible community event icon
   title: Events
-  intro: Share and learn about automation at Ansible events, in person or online.
-  url: https://forum.ansible.com/c/events/
-  view_calendar: View more
-  event_descriptions:
-    # This section contains various event descriptions.
-    # Copy and paste these descriptions as needed when updating event details.
-    # Changing below does not change text on the homepage. The value of the "events_list.<event>.description" key is used on the homepage.
-    community_day: Get together with a broad community of users, contributors, entusiasts, IT professionals and more to learn and share about Ansible automation.
-    contributor_summit: Interact with the Ansible contributor community and Ansible at Red Hat engineers to improve collaboration and possibly do some hacking.
-  events_list:
-    event_one:
-      name: Configuration Management Camp
-      # If the event is community day or contributor summit, you can copy the description from event_descriptions.
-      # Important: To prevent reflow and text wrapping issues on the homepage descriptions should be approximately 100 characters long.
-      description: Configuration Management Camp is the event for technologists interested in open source infrastructure automation and related topics.
-      date: February 5 to 7, 2024
-      location: Ghent, Belgium
-      image: cfgmgmtcamp-logo.png
-      alt: CfgMgmtCamp logo
-      link: https://forum.ansible.com/t/config-management-camp/91
-    event_two:
-      name: Ansible Minneapolis Meetup
-      # If the event is community day or contributor summit, you can copy the description from event_descriptions.
-      # Important: To prevent reflow and text wrapping issues on the homepage descriptions should be approximately 100 characters long.
-      description: Join a group of systems engineers and DevOps folks who want to Ansible all the things. Learn more and share your Ansible knowledge.
-      date: January 18, 2024
-      location: Minneapolis, MN, USA
-      image: ansible-meetup.svg
-      alt: Ansible meetup logo
-      link: https://forum.ansible.com/t/ansible-minneapolis-meetup-topic-tba-2024-01-18/1863
 platform:
   main: Get enterprise engineering and support from Red Hat with a platform that can tackle any automation challenge.
   discover: Red Hat Ansible Automation Platform provides everything needed to create, execute, and manage automation in a single subscription. From execution environments to certified collections to automation analytics, discover the features and benefits of Ansible Automation Platform.
@@ -124,18 +98,6 @@ ecosystem:
       link: https://ansible.readthedocs.io/projects/rulebook/
       logo: project-logos/eda.svg
       alt: Event-Driven Ansible project logo
-    devtools:
-      heading: Ansible automation developer tools
-      description: Tooling to develop and test Ansible content for consistent, trusted automation.
-      link: https://ansible.readthedocs.io/projects/dev-tools/
-      logo: project-logos/ansible-community.svg
-      alt: Ansible DevTools project logo
-blog:
-  section_icon: /assets/images/blog-cyan.svg
-  icon_alt: Ansible community blog icon
-  title: Blog
-  intro: Check out some recent blog posts from the Ansible community.
-  url: /blog/
 contribute:
   section_icon: /assets/images/collaboration-cyan.svg
   icon_alt: Ansible community contributor icon
@@ -165,3 +127,33 @@ links:
   platform:
     home: https://www.redhat.com/en/technologies/management/ansible
     use_cases: https://www.redhat.com/en/technologies/management/ansible/use-cases
+catalyst:
+  section_icon: /assets/images/orchestration-cyan.svg
+  icon_alt: Ansible Catalyst program icon
+  title: Ansible Catalyst
+  intro: This is a newly-formed program lead by Red Hat to foster additional user interaction, showcase the ecosystem contributions, and share insights on driving automation adoption at your organization.
+  articles:
+    collection_spotlight:
+      heading: Collection spotlight
+      description: Every week we will highlight a new collection available to the Ansible ecosystem.
+      data_title: Ansible Middleware
+      data_body: Have you had a chance to check out the Ansible based automation for Red Hat Application Services and upstream middleware projects?
+      link: https://galaxy.ansible.com/ui/namespaces/middleware_automation/
+    contributions:
+      heading: Innovation by automation
+      description: Using automation to drive innovation enabling business value should always be the end goal.
+      data_title: What's currently brewing in your creative canvas?
+      data_body: Take a moment to visit our forum and tell your fellow users what you are working on.
+      link: https://forum.ansible.com/c/chat/4
+    adoption:
+      heading: Automation adoption
+      description: Have questions about how you can expand adoption of automation with your organization? If so, check out the following article to learn some tips and tricks.
+      data_title: Building your own automation community
+      data_body: Creating and supporting successful communities is something Red Hat has done for a long time. We would love to share our community adoption framework with you.
+      link: 
+    f2e:
+      heading: Enterprise automation
+      description: Curious about the journey from AWX to Red Hat Ansible Automation Platform?
+      data_title: When should an organization consider upgrading to expand their enterprise-grade automation strategy?
+      data_body: This article will help you define your organization's automation maturity and aid in determining if it is time to level up your strategy.
+      link: 

--- a/pages/awx.md
+++ b/pages/awx.md
@@ -22,7 +22,7 @@ The AWX project is how Red Hat and Ansible demonstrate their commitment to creat
 
 Here are resources to help start using AWX and get involved with the community:
 
-* Check the [frequently asked questions about AWX](#faq) on this page.
+* Check the [frequently asked questions about AWX](link://slug/faq) on this page.
 * Fork the [AWX GitHub repository](https://github.com/ansible/awx).
 * Check out the [AWX operator](https://github.com/ansible/awx-operator/) for Kubernetes.
 * Visit the [AWX documentation](https://ansible.readthedocs.io/projects/awx/en/latest/).
@@ -30,103 +30,3 @@ Here are resources to help start using AWX and get involved with the community:
 You can [get help](https://forum.ansible.com/tags/c/help/6/all/awx) with AWX on the community forum or [join a project discussion](https://forum.ansible.com/tags/c/project/7/awx) and become an active voice in the community.
 
 If you want to ask questions and talk with community experts, you can also visit the [#awx](https://matrix.to/#/#awx:ansible.com) channel on Matrix.
-
-<a name="faq"><a>
-
-# Frequently Asked Questions
-
-Find answers related to the AWX project in the following section.
-You can also find lots of information about AWX in the [Ansible community forum](https://forum.ansible.com/tag/awx).
-
-## What is the AWX project?
-
-The AWX project—AWX for short—is an open source community project, sponsored by Red Hat, that enables users to better control their community Ansible project use in IT environments.
-AWX is the upstream project from which the automation controller component is derived.
-
-Visit the [Understanding Ansible, AWX, and Ansible Automation Platform](https://www.redhat.com/en/technologies/management/ansible/compare-awx-vs-ansible-automation-platform) to understand the differences between community Ansible and Red Hat Ansible Automation Platform.
-
-## Why is Red Hat doing this?
-
-Open sourcing everything is what Red Hat does.
-When Ansible, Inc. was acquired by Red Hat, we told our users that we would open the source code for Ansible.
-The AWX project is a fulfillment of that intent.
-
-More importantly, the Ansible team believes deeply in the power of community-driven innovation.
-The Ansible project itself has more than 3,000 contributors and we believe this will continue to grow and expand.
-Many of the critical features we now provide for users and customers were built almost entirely by the Ansible community.
-We believe that the open source model will bring many innovations to the AWX project.
-
-## What is the difference between AWX and Automation Controller?
-
-AWX is designed to be a frequently released, fast-moving project where all new development happens.
-
-Automation Controller is produced by taking selected releases of AWX, hardening them for long-term supportability, and making them available to customers as a hosted service within Red Hat Ansible Automation Platform.
-Ansible Automation Platform is fully supported by Red Hat, while AWX is supported by the community.
-
-This is a tested and trusted method of software development for Red Hat, which follows a similar model to Fedora and Red Hat Enterprise Linux.
-
-## Where can I get help for AWX?
-
-You can [get help](https://forum.ansible.com/tags/c/help/6/all/awx) with AWX on the community forum or [join a project discussion](https://forum.ansible.com/tags/c/project/7/awx) and become an active voice in the community.
-
-If you want to ask questions and talk with community experts, you can also visit the [#awx](https://matrix.to/#/#awx:ansible.com) channel on Matrix.
-
-Because AWX is designed to be a rapidly moving project, Red Hat does not provide any paid support for it.
-For a fully supported automation management platform, [read more about Red Hat Ansible Automation Platform](https://www.redhat.com/en/technologies/management/ansible).
-
-## Can I upgrade from one version of AWX to another?
-
-AWX is versionless and offers a "latest" release version only.
-As such, it is not possible to perform direct, in-place upgrades between AWX versions.
-
-## Under which open source license is AWX available?
-
-The AWX source code is available under the [Apache License 2.0](https://github.com/ansible/awx/blob/devel/LICENSE.md).
-
-## How can I get involved with the AWX project?
-
-Fork or clone the [AWX GitHub repository](https://github.com/ansible/awx).
-We welcome and encourage community contributions.
-Read the [contributor guide](https://github.com/ansible/awx/blob/devel/CONTRIBUTING.md) to find out more.
-
-## Where do I report an AWX bug?
-
-You can file issues in the [issue tracking section](https://github.com/ansible/awx/issues) of the GitHub repository.
-
-## How often is AWX released?
-
-The AWX team currently plans to release new builds approximately every two weeks.
-The AWX team will flag certain builds as "stable" at their discretion.
-Note that the term "stable" does not imply fitness for production usage or any kind of warranty whatsoever.
-
-## What is the governance structure of the AWX project?
-
-For now, the AWX team will continue to make all decisions for the AWX project.
-Over time, we will evaluate our governance structure, and we will do our best to choose a structure that balances community needs with product needs.
-
-## If my software runs with AWX, can I say that it is certified to run on AWX or on Red Hat Ansible Automation Platform?
-
-No.
-Only Red Hat has the ability to say that software is "certified", although you may truthfully use the AWX name to describe the relationship between your software and AWX.
-For more details, consult the [AWX trademark guidelines](https://github.com/ansible/awx-logos/blob/master/TRADEMARKS.md).
-
-## I want to build my own forked version of AWX. Can I call it AWX? Can I call it Red Hat Ansible Automation Platform?
-
-No.
-You may fork AWX like any open source codebase, but you may not use Red Hat trademarks.
-Red Hat reserves the exclusive right to decide what products can bear those marks.
-
-## Will contributions to AWX require a "Contributor License Agreement"?
-
-No.
-However, all contributions to AWX will require agreement with the Developer Certificate of Origin (DCO) at the time of submission.
-The text of the DCO can be read in full at [developercertificate.org](https://developercertificate.org/).
-
-## Does Red Hat recommend AWX for production environments?
-
-No.
-Red Hat Ansible Automation Platform is suitable for production environments.
-
-## Does Red Hat’s Open Source Assurance Program apply to AWX?
-
-No, it does not.

--- a/pages/contact-us.md
+++ b/pages/contact-us.md
@@ -56,7 +56,7 @@ Get in touch with us if you need help or have questions.
   </div>
   <div class="contact-page-community-column">
     <h1>Ansible community</h1>
-    <p>For queries and assistance related to the Ansible community:</p>
+    <p>For queries and assistance related to the Ansible&reg; community:</p>
       <ul>
         <li>
           <a href="https://forum.ansible.com/g?type=public"
@@ -75,7 +75,7 @@ Get in touch with us if you need help or have questions.
              target="_blank">Get help by asking questions directly to the Ansible community.</a>
         </li>
       </ul>
-    <p>If you still have questions or need help, you can get in touch with the Ansible community team at Red Hat. Please send an email to <a href="mailto:ansible-community@redhat.com">ansible-community@redhat.com</a></p>
+    <p>If you still have questions or need help, you can get in touch with the Ansible community team at Red Hat&reg; by emailing <a href="mailto:ansible-community@redhat.com">ansible-community@redhat.com</a></p>
   </div>
 </div>
 <hr class="contact-page-rule" />
@@ -88,6 +88,6 @@ Get in touch with us if you need help or have questions.
   <div class="contact-page-platform-column">
     <h1>Red Hat Ansible Automation Platform</h1>
     <p>Visit the <a href="https://www.redhat.com/en/technologies/management/ansible" target="_blank">Red Hat Ansible Automation Platform</a> page to find out how it can solve your most challenging IT problems. You can find lots of resources and support for using Ansible Automation Platform across a variety of use cases.</p>
-    <p>You can also <a href="https://www.redhat.com/en/contact" target="_blank">contact Red Hat</a> directly with questions or to ask for help.</p>
+    <p>You can also <a href="https://www.redhat.com/en/contact" target="_blank">contact Red Hat&reg;</a> directly with questions or to ask for help.</p>
   </div>
 </div>

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -1,0 +1,225 @@
+---
+slug: faq
+title: Frequently asked questions
+description: Find answers to some of the frequently asked questions here.
+type: text
+---
+<style>
+h2 {
+  font-size: 2rem;
+  text-transform: none;
+}
+h3,
+h4,
+h5,
+h6 {
+  font-size: 1.125rem;
+  font-weight: normal;
+  text-transform: uppercase;
+}
+</style>
+Find answers related to the AWX project in the following section.
+You can also find lots of information about AWX in the [Ansible community forum](https://forum.ansible.com/tag/awx).
+
+# Core
+
+[Q: What is the difference between Ansible Core and AWX?](#1)
+
+# AWX
+
+[Q: What is The AWX Project?](#2)
+
+[Q: Why is Red Hat doing this?](#3)
+
+[Q: What’s the difference between AWX and automation controller?](#4)
+
+[Q: Where can I find support for AWX?](#5)
+
+[Q: Can I upgrade from one version of AWX to another?](#6)
+
+[Q: Under which open source license is AWX available?](#7)
+
+[Q: How can I get involved with the AWX Project?](#8)
+
+[Q: Where do I report an AWX bug?](#9)
+
+[Q: How often is AWX released?](#10)
+
+[Q: What is the governance structure of the AWX project?](#11)
+
+[Q: If my software runs with AWX, can I say that it is certified to run on AWX or on Red Hat Ansible Automation Platform?](#12)
+
+[Q: I want to build my own forked version of AWX. Can I call it AWX? Can I call it Red Hat Ansible Automation Platform?](#13)
+
+[Q: Will contributions to AWX require a “Contributor License Agreement”?](#14)
+
+[Q: Does Red Hat recommend AWX for production environments?](#15)
+
+[Q: Does Red Hat’s Open Source Assurance Program apply to AWX?](#16)
+
+# Ansible Community
+
+[Q: How can I contribute back to the community?](#17)
+
+# Core
+
+<a name="1"/>
+
+**What is the difference between Ansible Core and AWX?**
+
+Ansible Core is the command-line (CLI) tool that is installed from either community repositories or the official Red Hat repositories for Ansible.
+
+ansible-core is the successor to the "batteries included" ansible CLI package prior to Ansible 2.10, minus most of the modules that were split into collections.
+
+AWX provides a web-based user interface, REST API, and task engine built on top of Ansible.
+It's the upstream of automation controller (formerly Ansible Tower).
+Both are upstream projects for Red Hat Ansible Automation Platform.
+
+---
+
+# AWX
+
+<a name="2"/>
+
+**What is The AWX Project?**
+
+The AWX project—AWX for short—is an open source community project, sponsored by Red Hat®, that enables users to better control their community Ansible project use in IT environments.
+AWX is the upstream project from which the automation controller (formerly Ansible Tower) component in Red Hat Ansible Automation Platform is ultimately derived.
+
+<a name="3"/>
+
+**Why is Red Hat doing this?**
+
+Open sourcing everything is what Red Hat does.
+When Ansible®, Inc. was acquired by Red Hat, we told our users that we would open the source code for Ansible.
+The AWX project is a fulfillment of that intent.
+
+More importantly, the Ansible team—like all of Red Hat—believes deeply in the power of community-driven innovation.
+The Ansible project itself has more than 5,000 contributors, and we believe this will continue to grow and expand.
+Many of the critical features we now provide for users and customers were built almost entirely by the Ansible community.
+We believe that the open source model has brought many innovations to the AWX Project.
+
+[Learn more about Red Hat Ansible Automation Platform, the subscription-based, supported enterprise product](https://www.redhat.com/en/technologies/management/ansible)
+
+<a name="4"/>
+
+**What’s the difference between AWX and automation controller?**
+
+AWX is designed to be a frequently released, fast-moving project where all new development happens.
+
+Automation controller is produced by taking selected releases of AWX, hardening them for long-term supportability, and making them available to customers as a hosted service within Red Hat Ansible Automation Platform.
+Ansible Automation Platform is fully supported by Red Hat, while AWX is supported by the community.
+
+This is a tested and trusted method of software development for Red Hat, which follows a similar model to Fedora and Red Hat Enterprise Linux®.
+
+[Learn more about the differences between AWX and Red Hat Ansible Automation Platform](https://www.redhat.com/en/technologies/management/ansible/compare-awx-vs-ansible-automation-platform)
+
+<a name="5"/>
+
+**Where can I find support for AWX?**
+
+The community can help answer questions about AWX via the [Ansible Community Forum](https://forum.ansible.com) and Matrix.
+You can also file bug reports or contribute bug fixes in the [AWX GitHub repository](https://github.com/ansible/awx).
+
+Because AWX is designed to be a rapidly moving project, Red Hat does not provide any paid support for it.
+For a fully supported automation management platform, read more about [Red Hat Ansible Automation Platform](https://www.redhat.com/en/technologies/management/ansible).
+
+<a name="6"/>
+
+**Can I upgrade from one version of AWX to another?**
+
+Upgrading of AWX is only available for the awx-operator (Kubernetes) based install.
+For upgrading awx-operator from version 0.18 or above, [follow the instructions in this document](https://github.com/ansible/awx-operator/blob/devel/docs/upgrade/upgrading.md).
+Direct, in-place [upgrades between prior AWX versions are not supported](https://github.com/ansible/awx/blob/devel/DATA_MIGRATION.md).
+
+<a name="7"/>
+
+**Under which open source license is AWX available?**
+
+The AWX source code is available under the Apache License 2.0.
+
+<a name="8"/>
+
+**How can I get involved with the AWX Project?**
+
+The AWX Project is [hosted on GitHub](https://github.com/ansible/awx). We welcome community contributions.
+Read the [contributor guide](https://github.com/ansible/awx/blob/devel/CONTRIBUTING.md).
+Join the [Ansible Community Forum](https://forum.ansible.com).
+
+<a name="9"/>
+
+**Where do I report an AWX bug?**
+
+The AWX project uses GitHub for its issue tracking. You can file your issues [on this page](https://github.com/ansible/awx/issues).
+
+<a name="10"/>
+
+**How often is AWX released?**
+
+The AWX team currently plans to release new builds approximately every 2 weeks.
+The AWX team will flag certain builds as “stable” at their discretion. Note that the term “stable” does not imply fitness for production usage or any kind of warranty.
+
+<a name="11"/>
+
+**What is the governance structure of the AWX project?**
+
+For now, the Red Hat sponsored AWX team will continue to make the majority of decisions for the AWX project, with input from the community.
+Over time, the team will evaluate its governance structure and choose a structure that balances community needs with product needs.
+
+<a name="12"/>
+
+**If my software runs with AWX, can I say that it is certified to run on AWX or on Red Hat Ansible Automation Platform?**
+
+No. Only Red Hat has the ability to say that software is “certified,” although you may truthfully use the AWX name to describe the relationship between your software and AWX.
+For more details, consult the [AWX trademark guidelines](https://github.com/ansible/awx-logos/blob/master/TRADEMARKS.md).
+
+<a name="13"/>
+
+**I want to build my own forked version of AWX. Can I call it AWX? Can I call it Red Hat Ansible Automation Platform?**
+
+No.
+You may fork AWX like any open source codebase, but you may not use Red Hat trademarks.
+Red Hat reserves the exclusive right to decide what products can bear those marks.
+Be sure to read the [AWX trademark guidelines](https://github.com/ansible/awx-logos/blob/master/TRADEMARKS.md) for more information.
+
+<a name="14"/>
+
+**Will contributions to AWX require a “Contributor License Agreement”?**
+
+No.
+However, all contributions to AWX will require agreement with the Developer Certificate of Origin (DCO) at the time of submission.
+The text of the DCO can be read in full at [developercertificate.org](http://developercertificate.org/).
+
+<a name="15"/>
+
+**Does Red Hat recommend AWX for production environments?**
+
+No.
+
+<a name="16"/>
+
+**Does Red Hat’s Open Source Assurance Program apply to AWX?**
+
+No.
+
+---
+
+# Ansible Community
+
+<a name="17"/>
+
+**How can I contribute back to the community?**
+
+We are pleased to shared there are so many ways to contribute to the Ansible ecosystem.
+Here are just a few examples:
+
+* Organize meetups with other automation enthusiasts
+* Present at conferences about Ansible
+* Host Ansible workshops
+* Share content on Galaxy
+* Code a new module or collection
+* Report or fix a bug
+* Improve the documentation
+
+Want to get involved?
+Check out our [contributor resources](https://forum.ansible.com/pub/how-to-contribute) or chat with [community members](https://matrix.to/#/#social:ansible.com) - we'd love to have you.

--- a/pages/how-ansible-works.md
+++ b/pages/how-ansible-works.md
@@ -35,11 +35,11 @@ For automating network devices and other IT appliances where modules cannot be e
 
 <img src="../images/pages/network-automation-comparison.jpg" alt="Network automation local and remote execution diagram" style="height: auto; width:500px;"/>
 
-For automating public clouds and web services, Ansible will also run modules locally and talk directly to their APIs. For more information, read these docs:
+For automating public clouds and web services, Ansible will also run modules locally and talk directly to their APIs. For more information, review these collections:
 
 * [Amazon Web Services Guide](https://docs.ansible.com/ansible/latest/collections/amazon/aws/docsite/guide_aws.html#ansible-collections-amazon-aws-docsite-aws-intro)
-* [Google Cloud Platform Guide](https://docs.ansible.com/ansible/latest/scenario_guides/guide_gce.html)
-* [Microsoft Azure Guide](https://docs.ansible.com/ansible/latest/scenario_guides/guide_azure.html)
+* [Google Cloud Collection](https://docs.ansible.com/ansible/latest/collections/google/cloud/index.html)
+* [Microsoft Azure Collection](https://docs.ansible.com/ansible/latest/collections/azure/azcollection/index.html#plugins-in-azure-azcollection)
 
 # Credentials
 
@@ -48,9 +48,9 @@ For Ansible to execute, it needs an inventory (what are the managed nodes I am t
 Community Ansible is decentralized—meaning it relies on your existing OS credentials to control access to remote machines.
 And if needed, Ansible can easily connect with Kerberos, Lightweight Directory Access Protocol (LDAP), and other centralized authentication management systems. You can also just store usernames and passwords as variables for Ansible and encrypt them with [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html). This can be as easy as storing them in your inventory file, as elaborated on below.
 
-Red Hat Ansible Automation Platform [can centralized authentication](https://docs.ansible.com/automation-controller/latest/html/userguide/credentials.html) as well as integrate with industry-standard tools like CyberArk AIM, Conjur, HashiCorp Vault, and Microsoft Azure Key Vault. Automation controller hashes local automation controller user passwords with the PBKDF2 algorithm using a SHA256 hash. Users who authenticate via external account mechanisms (LDAP, SAML, OAuth, and others) do not have any password or secret stored.
+Red Hat Ansible Automation Platform [can centralized authentication](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/controller-credentials) as well as integrate with industry-standard tools like CyberArk AIM, Conjur, HashiCorp Vault, and Microsoft Azure Key Vault. Automation controller hashes local automation controller user passwords with the PBKDF2 algorithm using a SHA256 hash. Users who authenticate via external account mechanisms (LDAP, SAML, OAuth, and others) do not have any password or secret stored.
 
-[Read the secret handling and connection security documentation...](https://docs.ansible.com/automation-controller/latest/html/administration/secret_handling.html#ag-secret-handling)
+[Read the secret handling and connection security documentation...](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/automation_controller_administration_guide/controller-secret-handling-and-connection-security)
 
 
 # Manage your inventory in simple text files
@@ -59,7 +59,7 @@ By default, Ansible represents which machines it manages using a very simple INI
 
 To add new machines, there is no additional SSL signing server involved, so there's never any hassle deciding why a particular machine didn’t get linked up due to obscure NTP or DNS issues.
 
-If there's another source of truth in your infrastructure, Ansible can also plug in to that, such as drawing inventory, group, and variable information from sources like Amazon Web Services, Google Compute Engine, Microsoft Azure, VMware vCenter, and more. Both community Ansible and Ansible Automation Platform can use a variety of [dynamic inventory plugins](https://docs.ansible.com/ansible/latest/plugins/inventory.html). Ansible Automation Platform makes these easily [available and configurable in the WebUI](https://docs.ansible.com/automation-controller/latest/html/userguide/inventories.html#inventory-plugins).
+If there's another source of truth in your infrastructure, Ansible can also plug in to that, such as drawing inventory, group, and variable information from sources like Amazon Web Services, Google Compute Engine, Microsoft Azure, VMware vCenter, and more. Both community Ansible and Ansible Automation Platform can use a variety of [dynamic inventory plugins](https://docs.ansible.com/ansible/latest/plugins/inventory.html). Ansible Automation Platform makes these easily [available and configurable in the WebUI](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/controller-inventories#ref-controller-inventory-plugins).
 
 Here's what a plain text inventory file looks like:
 

--- a/pages/how-ansible-works.md
+++ b/pages/how-ansible-works.md
@@ -3,62 +3,55 @@ slug: how-ansible-works
 title: How Ansible works
 type: text
 ---
-Learn the fundamentals of Ansible, powerful IT automation software that emphasizes simplicity and ease of use.
-
 Ansible is an open source, command-line IT automation software application written in Python. It can configure systems, deploy software, and orchestrate advanced workflows to support application deployment, system updates, and more.
 
 Ansible’s main strengths are simplicity and ease of use. It also has a strong focus on security and reliability, featuring minimal moving parts. It uses OpenSSH for transport (with other transports and pull modes as alternatives), and uses a human-readable language that is designed for getting started quickly without a lot of training.
 
-**Comparing community Ansible with Red Hat Ansible Automation Platform?**
-Visit the [Understanding Ansible, AWX, and Ansible Automation Platform](https://www.redhat.com/en/technologies/management/ansible/compare-awx-vs-ansible-automation-platform) to understand the differences.
+Comparing community Ansible with Red Hat Ansible Automation Platform?  [Understanding the differences](https://www.redhat.com/en/technologies/management/ansible/compare-awx-vs-ansible-automation-platform)
 
 # Community Ansible
 
-The community distribution of Ansible contains a suite of powerful command line tools supported on most operating systems with Python installed.
-This includes Red Hat Enterprise Linux, Debian, Ubuntu, MacOS, FreeBSD, Microsoft Windows, and more.
-For more information on installing Ansible refer to the [installation documentation](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html).
+The community distribution of Ansible contains a suite of powerful command line tools supported on most operating systems with Python installed. This includes Red Hat Enterprise Linux, Debian, Ubuntu, MacOS, FreeBSD, Microsoft Windows, and more.
+For more information on installing Ansible [refer to the installation documentation](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html).
 
 # Red Hat Ansible Automation Platform
 
-Red Hat Ansible Automation Platform is a subscription product built on the foundations of Ansible with numerous enterprise features.
-It combines more than a dozen upstream projects into an integrated, streamlined product. Each product component also has a specific purpose with a well-defined scope.
-For example, the automation controller is the WebUI and API for Ansible automation, which is based on the upstream project AWX.
-This component is bundled into the platform to manage automation.
-Ansible Automation Platform is available to be run on-premise and charged by node (rather than by user), or you can use the managed service offering on Microsoft Azure.
+Red Hat Ansible Automation Platform is a subscription product built on the foundations of Ansible with numerous enterprise features. It combines more than a dozen upstream projects into an integrated, streamlined product. Each product component also has a specific purpose with a well-defined scope. For example, the automation controller is the WebUI and API for Ansible automation, which is based on the upstream project AWX. This component is bundled into the platform to manage automation. Ansible Automation Platform is available to be run on-premise and charged by node (rather than by user), or you can use the [managed service offering on Microsoft Azure](https://www.redhat.com/en/technologies/management/ansible/azure).
+
+This page will give you an overview of Ansible fundamentals that apply to both community Ansible and Red Hat Ansible Automation Platform. For more detail, please visit [http://docs.ansible.com/](docs.ansible.com).
+
+
+| Red Hat Ansible Automation Platform: A beginner’s guide <br><br>[Get the e-book](https://www.redhat.com/en/engage/redhat-ansible-automation-20220412) |   | Explore Ansible Automation Platform learning materials and tools<br><br>[Visit the learning hub](https://www.redhat.com/en/engage/automation-at-edge-20220727) |
+|-------------------------------------------------------------------------------:|---|-----------------------------------------------------------------------------------------------:|
+<br><br>
 
 # Efficient architecture
 
-Both community Ansible and Ansible Automation Platform have the concept of a control node and a managed node.
-The control node is where Ansible is executed from, for example where a user runs the ansible-playbook command.
-Managed nodes are the devices being automated, for example a Microsoft Windows server.
+Both community Ansible and Ansible Automation Platform are built on the concept of a control node and a managed node. Ansible is executed from the control node—for example, where a user runs the ansible-playbook command. Managed nodes are the devices being automated—for example, a Microsoft Windows server.
 
-For automating Linux and Windows, Ansible works by connecting to managed nodes and pushing out small programs, called "Ansible modules," to them.
-These programs are written to be resource models of the desired state of the system.
-Ansible then executes these modules (over SSH by default), and removes them when finished.
-These modules are designed to be [idempotent](https://docs.ansible.com/ansible/latest/reference_appendices/glossary.html#term-Idempotency) when possible, so that they only make changes to a system when necessary.
+For automating Linux and Windows, Ansible connects to managed nodes and pushes out small programs—called Ansible modules—to them. These programs are written to be resource models of the desired state of the system. Ansible then executes these modules (over SSH by default), and removes them when finished. These modules are designed to be [idempotent](https://docs.ansible.com/ansible/latest/reference_appendices/glossary.html#term-Idempotency) when possible, so that they only make changes to a system when necessary.
 
-For automating network devices and other IT appliances where modules cannot be executed, Ansible will run on the control node.
-Since Ansible is agentless, it can still communicate with devices without requiring an application or service to be installed on the managed node.
-To increase execution capacity for devices without the ability to run modules, Ansible Automation Platform can spread automation jobs out across execution nodes using a technology called [automation mesh](https://www.redhat.com/en/technologies/management/ansible/automation-mesh).
-To understand more about how network automation is different, check out the [Ansible documentation](https://docs.ansible.com/ansible/latest/network/getting_started/network_differences.html).
+For automating network devices and other IT appliances where modules cannot be executed, Ansible runs on the control node. Since Ansible is agentless, it can still communicate with devices without requiring an application or service to be installed on the managed node. To increase execution capacity for devices without the ability to run modules, Ansible Automation Platform can spread automation jobs out across execution nodes using a technology called [automation mesh](https://www.redhat.com/en/technologies/management/ansible/automation-mesh). To understand more about how network automation works, [read the e-book](https://www.redhat.com/en/engage/network-automation-everyone-s-202101221234).
 
 <img src="../images/pages/network-automation-comparison.jpg" alt="Network automation local and remote execution diagram" style="height: auto; width:500px;"/>
 
-For automating public clouds and web services, Ansible will also run modules locally and talk directly to their APIs.
+For automating public clouds and web services, Ansible will also run modules locally and talk directly to their APIs. For more information, read these docs:
+
+* [Amazon Web Services Guide](https://docs.ansible.com/ansible/latest/collections/amazon/aws/docsite/guide_aws.html#ansible-collections-amazon-aws-docsite-aws-intro)
+* [Google Cloud Platform Guide](https://docs.ansible.com/ansible/latest/scenario_guides/guide_gce.html)
+* [Microsoft Azure Guide](https://docs.ansible.com/ansible/latest/scenario_guides/guide_azure.html)
 
 # Credentials
 
 For Ansible to execute, it needs an inventory (what are the managed nodes I am trying to automate?) and credentials (how do I login and connect to those managed nodes?).
 
 Community Ansible is decentralized—meaning it relies on your existing OS credentials to control access to remote machines.
-And if needed, Ansible can easily connect with Kerberos, Lightweight Directory Access Protocol (LDAP), and other centralized authentication management systems.
-You can also just store usernames and passwords as variables for Ansible and encrypt them with [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html).
-This can be as easy as storing them in your inventory file, as elaborated on below.
+And if needed, Ansible can easily connect with Kerberos, Lightweight Directory Access Protocol (LDAP), and other centralized authentication management systems. You can also just store usernames and passwords as variables for Ansible and encrypt them with [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html). This can be as easy as storing them in your inventory file, as elaborated on below.
 
-Red Hat Ansible Automation Platform [can act as a centralized authentication](https://docs.ansible.com/automation-controller/latest/html/userguide/credentials.html) as well as integrate with industry-standard tools like CyberArk AIM, Conjur, HashiCorp Vault, and Microsoft Azure Key Vault.
-Automation controller hashes local automation controller user passwords with the PBKDF2 algorithm using a SHA256 hash.
-Users who authenticate via external account mechanisms (LDAP, SAML, OAuth, and others) do not have any password or secret stored.
-For more information, check the [Secret handling and connection security](https://docs.ansible.com/automation-controller/latest/html/administration/secret_handling.html#ag-secret-handling) documentation.
+Red Hat Ansible Automation Platform [can centralized authentication](https://docs.ansible.com/automation-controller/latest/html/userguide/credentials.html) as well as integrate with industry-standard tools like CyberArk AIM, Conjur, HashiCorp Vault, and Microsoft Azure Key Vault. Automation controller hashes local automation controller user passwords with the PBKDF2 algorithm using a SHA256 hash. Users who authenticate via external account mechanisms (LDAP, SAML, OAuth, and others) do not have any password or secret stored.
+
+[Read the secret handling and connection security documentation...](https://docs.ansible.com/automation-controller/latest/html/administration/secret_handling.html#ag-secret-handling)
+
 
 # Manage your inventory in simple text files
 
@@ -66,9 +59,7 @@ By default, Ansible represents which machines it manages using a very simple INI
 
 To add new machines, there is no additional SSL signing server involved, so there's never any hassle deciding why a particular machine didn’t get linked up due to obscure NTP or DNS issues.
 
-If there's another source of truth in your infrastructure, Ansible can also plug in to that, such as drawing inventory, group, and variable information from sources like Amazon Web Services, Google Compute Engine, Microsoft Azure, VMware vCenter, and more.
-Both community Ansible and Ansible Automation Platform can use a variety of [dynamic inventory plugins](https://docs.ansible.com/ansible/latest/plugins/inventory.html).
-Ansible Automation Platform makes these easily [available and configurable in the WebUI](https://docs.ansible.com/automation-controller/latest/html/userguide/inventories.html#inventory-plugins).
+If there's another source of truth in your infrastructure, Ansible can also plug in to that, such as drawing inventory, group, and variable information from sources like Amazon Web Services, Google Compute Engine, Microsoft Azure, VMware vCenter, and more. Both community Ansible and Ansible Automation Platform can use a variety of [dynamic inventory plugins](https://docs.ansible.com/ansible/latest/plugins/inventory.html). Ansible Automation Platform makes these easily [available and configurable in the WebUI](https://docs.ansible.com/automation-controller/latest/html/userguide/inventories.html#inventory-plugins).
 
 Here's what a plain text inventory file looks like:
 
@@ -86,20 +77,17 @@ Once inventory hosts are listed, variables can be assigned to them in simple tex
 
 Or, as already mentioned, you can use a dynamic inventory to pull your inventory from data sources like AWS and Azure.
 
-# Playbooks: A simple and powerful automation language
+# Ansible Playbooks: A simple and powerful automation language
 
-Playbooks can finely orchestrate multiple slices of your IT infrastructure, with very detailed control over how many machines to tackle at a time.
-This is where Ansible starts to get most interesting.
+Playbooks can finely orchestrate multiple slices of your IT infrastructure, with very detailed control over how many machines to tackle at a time. This is where Ansible starts to get most interesting.
+
+<p style="text-align: center;"><iframe width="454" height="257" src="https://www.youtube.com/embed/VRoQLVHdNHE" title="Open Answers: What is patch management?" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></p>
 
 Ansible's approach to orchestration is one of finely tuned simplicity, as we believe you should be able to use existing knowledge while not having to remember special syntax or features.
 
-Visit the ["Open Answers: What is patch management?"](https://youtu.be/VRoQLVHdNHE?si=Xc9hG0H9F0NjHpIs) video to hear Red Hat's Sean Cavanaugh explain things in more detail.
+Here's what a playbook looks like. As a reminder, this is only here as a teaser - visit [docs.ansible.com](https://docs.ansible.com/) for the complete documentation, and see all that's possible.
 
-Here's what a playbook looks like.
-As a reminder, this is only here as a teaser.
-Visit [docs.ansible.com](https://docs.ansible.com/) for the complete documentation, and see all that's possible.
-
-An example `apache.yml` playbook might look like:
+**An example `apache.yml` playbook might look like:**
 
 ```yaml
 ---
@@ -124,11 +112,10 @@ An example `apache.yml` playbook might look like:
       src: web.html
       dest: /var/www/html/index.html
 ```
+<p style="text-align: center;"><a href="https://github.com/ansible/workshops/blob/devel/exercises/ansible_rhel/1.3-playbook/apache.yml">Github source</a></p>
 
-You can find the source for the preceding `apache.yml` in [this GitHub repository](https://github.com/ansible/workshops/blob/devel/exercises/ansible_rhel/1.3-playbook/apache.yml).
 
-The Ansible documentation explores this in much greater depth.
-There’s a LOT more that you can do, including:
+The Ansible documentation explores this in much greater depth. There’s a LOT more that you can do, including:
 
 * Take machines in and out of load balancers and monitoring windows.
 * Have one server know the IP address of all the others, using facts gathered about those particular servers—and use those to dynamically build out configuration files.
@@ -141,36 +128,29 @@ Most importantly, the language remains readable and transparent, and you never h
 
 # Extend Ansible: plugins, modules, and API
 
-Should you want to write your own, Ansible modules can be written in any language that can return JSON (Ruby, Python, Powershell, bash, etc).
-Inventory can also plug in to any datasource by writing a program that speaks to that datasource and returns JSON.
-There's also various Python APIs for extending Ansible’s connection types (SSH is not the only transport possible), callbacks (how Ansible logs, etc), and even for adding new server-side behaviors.
+Should you want to write your own, Ansible modules can be written in any language that can return JSON (Ruby, Python, Powershell, bash, etc). You can also plug in an inventory to any datasource by writing a program that speaks to that datasource and returns JSON. There are also various Python APIs for extending Ansible’s connection types (SSH is not the only transport possible), callbacks (how Ansible logs, etc), and even for adding new server-side behaviors.
 
-# The difference between Ansible community projects and Red Hat Ansible Automation Platform
+# When would you use Ansible Automation Platform instead of community Ansible?
+Community Ansible is a great starting point for automation. But Red Hat Ansible Automation Platform is built with the needs of enterprise automators in mind. It delivers more capabilities for [event-driven automation](https://www.redhat.com/en/technologies/management/ansible/event-driven-ansible) and [generative AI](https://www.redhat.com/en/technologies/management/ansible/ansible-lightspeed), more control with added [security](https://www.redhat.com/en/technologies/management/ansible/gain-security-with-red-hat-ansible-automation-platform) and reporting tools, and more confidence with life cycle technical support—so you can scale automation across your organization in a flexible, standardized way. 
 
-Red Hat Ansible Automation Platform is a subscription product that builds upon the foundations of community Ansible and is designed to elevate automation across your organization.
+Here are 3 example instances of when Ansible Automation Platform might make sense for an organization:
 
-Flexible, security-focused, and capable, Ansible Automation Platform helps IT teams create, manage, and scale automation in a standardized way.
+* Ansible Automation Platform can help organizations with security and support by providing [fully certified and signed content](https://www.redhat.com/en/technologies/management/ansible/automation-hub). Your organization can know which automation content is the official content, and digitally signed Ansible content collections ensure an end-to-end software supply chain from development to production.
+* Ansible Automation Platform can help operationalize automation at scale with [automation mesh](https://www.redhat.com/en/technologies/management/ansible/automation-mesh) and [automation execution environments](https://www.redhat.com/en/technologies/management/ansible/automation-execution-environments). Automation mesh allows an enterprise to add resilience, automation capacity, and security to automation across IT infrastructure that spans multiple sites.
+* Ansible Automation Platform can also help an organization understand their automation footprint with [automation analytics](https://www.redhat.com/en/technologies/management/ansible/automation-analytics-insights). Automation analytics helps IT leaders and automation architects observe how teams are adopting automation and track the success of those efforts.
 
-With a subscription, you get fully supported and certified content from our robust partner ecosystem, expert knowledge gained from our success with thousands of customers, and differentiated services—like analytics reporting.
+[Learn more about Ansible Automation Platform...](https://www.redhat.com/en/technologies/management/ansible)
 
-Here are three example instances of when Red Hat Ansible Automation Platform might make sense for an organization:
+**Featured integrations**
 
-* Ansible Automation Platform can help organizations with security and support by providing [fully certified and signed content](https://www.redhat.com/en/technologies/management/ansible/automation-hub).
-  Your organization can know which automation content is the official content, and digitally signed Ansible content collections ensure an end-to-end software supply chain from development to production.
-* Ansible Automation Platform can help an organization with operationalizing automation at scale with [automation mesh](https://www.redhat.com/en/technologies/management/ansible/automation-mesh) and [automation execution environments](https://www.redhat.com/en/technologies/management/ansible/automation-execution-environments).
-  Automation mesh allows an enterprise organization to add resilience, automation capacity, and security to their automation fabric across their IT infrastructure across multiple sites.
-* Ansible Automation Platform can also help an organization understand their automation footprint with [automation analytics](https://www.redhat.com/en/technologies/management/ansible/automation-analytics-insights).
-  Automation analytics helps IT leaders and automation architects observe how teams are adopting automation and track the success of those efforts.
+Ansible includes hundres of modules to support a wide variety of integrations, including:
 
-To learn more about Red Hat Ansible Automation Platform, check out our knowledgebase article, [What is included in Red Hat Ansible Automation Platform subscription?](https://access.redhat.com/articles/6057451)
-
-# Further reading
-
-For additional reading, take a look at some of these e-books:
-
-* [Red Hat Ansible Automation Platform: A beginner’s guide](https://www.redhat.com/en/engage/redhat-ansible-automation-20220412)
-* [Automation at the edge: 7 industry use cases and examples](https://www.redhat.com/en/engage/automation-at-edge-20220727)
-* [Network automation for everyone](https://www.redhat.com/en/engage/network-automation-everyone-s-202101221234)
-* [Connect your hybrid cloud environment with IT automation](https://www.redhat.com/en/engage/hybrid-cloud-environment-20220412)
-* [The cost of human error and the advantages of security automation](https://www.redhat.com/en/resources/cost-human-error-advantage-security-automation-ebook)
-* [Simplify storage management](Simplify storage management)
+* [Arista](https://www.ansible.com/ansible-arista-networks?hsLang=en-us)
+* [AWS](https://www.ansible.com/integrations/cloud/amazon-web-services?hsLang=en-us)
+* [Cisco](https://www.ansible.com/integrations/networks/cisco?hsLang=en-us)
+* [F5](https://www.ansible.com/integrations/networks/f5?hsLang=en-us)
+* [Google Cloud Platform](https://www.ansible.com/integrations/cloud/google-cloud-platform?hsLang=en-us)
+* [Juniper](https://www.ansible.com/integrations/networks/juniper?hsLang=en-us)
+* [NetApp](https://www.ansible.com/integrations/infrastructure/netapp?hsLang=en-us)
+* [VMware](https://www.ansible.com/integrations/infrastructure/vmware?hsLang=en-us)
+* [Windows](https://www.ansible.com/for/windows?hsLang=en-us)

--- a/templates/homepage-ansible-band.tmpl
+++ b/templates/homepage-ansible-band.tmpl
@@ -15,6 +15,9 @@
       <p>{{ homepage.ansible.top_section.body }}</p>
       <h3>{{ homepage.ansible.bottom_section.heading }}</h3>
       <p>{{ homepage.ansible.bottom_section.body }}</p>
+      <span class="homepage-link"><a href="{{ homepage.ansible.mission_url }}">{{ homepage.ansible.mission }}</a></span>
+      <br>
+      <span class="homepage-link"><a href="{{ homepage.ansible.join_url }}" target="_blank">{{ homepage.ansible.join }}</a></span>
     </div>
   </div>
   <div class="ansible-image width-4-12 width-12-12-m">

--- a/templates/homepage-catalyst-band.tmpl
+++ b/templates/homepage-catalyst-band.tmpl
@@ -1,0 +1,26 @@
+<div class="grid-wrapper homepage-catalyst-band full-width-band"
+     id="catalyst">
+  <div class="section-title width-12-12 width-12-12-m">
+    <div class="section-top">
+      <img class="section-icon"
+           src="{{ homepage.catalyst.section_icon }}"
+           alt="{{ homepage.catalyst.icon_alt }}"
+           width="40"
+           height="40" />
+      <h2>{{ homepage.catalyst.title }}</h2>
+    </div>
+    <p>{{ homepage.catalyst.intro }}</p>
+  </div>
+  {% for key, item in homepage.catalyst.articles.items() %}
+    <div class="catalyst-card width-6-12 width-12-12-m">
+      <div class="catalyst-content">
+        <h3>{{ item.heading }}</h3>
+        <p>{{ item.description }}</p>
+        <h4>{{ item.data_title }}</h4>
+        <p>{{ item.data_body }}</p>
+        <span class="homepage-link"><a href="{{ item.link }}" target="_blank">{{ homepage.labels.learn_more }}</a>&ensp;<i class="fa fa-arrow-right" aria-hidden="true" /></span>
+      </div>
+    </div>
+  {% endfor %}
+  {% include "homepage-back-to-top.tmpl" %}
+</div>

--- a/templates/homepage-ecosystem-band.tmpl
+++ b/templates/homepage-ecosystem-band.tmpl
@@ -9,7 +9,7 @@
            height="40" />
       <h2>{{ homepage.ecosystem.title }}</h2>
       <div class="section-view-more">
-        <span class="homepage-link"><a href="{{ homepage.ecosystem.url }}" target="_blank">{{ homepage.labels.view_more }}</a>&ensp;<i class="fa fa-arrow-right" aria-hidden="true" /></span>
+        <span class="homepage-link"><a href="{{ homepage.ecosystem.url }}">{{ homepage.labels.view_more }}</a>&ensp;<i class="fa fa-arrow-right" aria-hidden="true" /></span>
       </div>
     </div>
     <p>{{ homepage.ecosystem.intro }}</p>

--- a/templates/homepage-tab-menu-band.tmpl
+++ b/templates/homepage-tab-menu-band.tmpl
@@ -8,6 +8,14 @@
            height="40" />
       <p>{{ homepage.ansible.title }}</p>
     </a>
+    <!-- Catalyst section -->
+    <a class="tab-menu-anchor" href="#catalyst" role="button">
+      <img src="{{ homepage.catalyst.section_icon }}"
+           alt="{{ homepage.catalyst.icon_alt }}"
+           width="40"
+           height="40" />
+      <p>{{ homepage.catalyst.title }}</p>
+    </a>
     <!-- Ecosystem section -->
     <a class="tab-menu-anchor" href="#ecosystem" role="button">
       <img src="{{ homepage.ecosystem.section_icon }}"
@@ -24,24 +32,11 @@
            height="40" />
       <p>{{ homepage.community.title }}</p>
     </a>
-    <!-- Blog section -->
-    <a class="tab-menu-anchor" href="#blog" role="button">
-      <img src="{{ homepage.blog.section_icon }}"
-           alt="{{ homepage.blog.icon_alt }}"
-           width="40"
-           height="40" />
-      <p>{{ homepage.blog.title }}</p>
-    </a>
-    <!-- Contribute section -->
-    <a class="tab-menu-anchor" href="#contribute" role="button">
-      <img src="{{ homepage.contribute.section_icon }}"
-           alt="{{ homepage.contribute.icon_alt }}"
-           width="40"
-           height="40" />
-      <p>{{ homepage.contribute.title }}</p>
-    </a>
     <!-- Events section -->
-    <a class="tab-menu-anchor" href="#events" role="button">
+    <a class="tab-menu-anchor"
+       href="https://forum.ansible.com/c/events/8"
+       target="_blank"
+       role="button">
       <img src="{{ homepage.events.section_icon }}"
            alt="{{ homepage.events.icon_alt }}"
            width="40"

--- a/templates/homepage.tmpl
+++ b/templates/homepage.tmpl
@@ -8,11 +8,9 @@
 {% block homepage_content %}
   {% include "homepage-tab-menu-band.tmpl" %}
   {% include "homepage-ansible-band.tmpl" %}
+  {% include "homepage-catalyst-band.tmpl" %}
   {% include "homepage-ecosystem-band.tmpl" %}
   {% include "homepage-community-band.tmpl" %}
-  {% include "homepage-bullhorn-band.tmpl" %}
-  {% include "homepage-blog-band.tmpl" %}
-  {% include "homepage-contribute-band.tmpl" %}
-  {% include "homepage-events-band.tmpl" %}
   {% include "homepage-platform-band.tmpl" %}
+  {% include "homepage-bullhorn-band.tmpl" %}
 {% endblock homepage_content %}

--- a/themes/ansible-community/sass/_homepage-catalyst-band.scss
+++ b/themes/ansible-community/sass/_homepage-catalyst-band.scss
@@ -1,5 +1,5 @@
 .homepage-catalyst-band {
-  background-color: $white;
+  background-color: $grey94;
 }
 
 .catalyst-card {

--- a/themes/ansible-community/sass/_homepage-catalyst-band.scss
+++ b/themes/ansible-community/sass/_homepage-catalyst-band.scss
@@ -1,0 +1,64 @@
+.homepage-catalyst-band {
+  background-color: $white;
+}
+
+.catalyst-card {
+  display: flex;
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+  transition: 0.3s;
+  padding: 2rem;
+  border-width: 1px;
+  border-radius: 5px;
+  background-color: $white;
+  justify-content: stretch;
+}
+
+.catalyst-content {
+  display: flex;
+  flex-direction: column;
+  padding-right: 2rem;
+  justify-content: space-between;
+
+  h3 {
+    font-size: $font-lg;
+    font-weight: 600;
+    text-transform: none;
+    color: $cyan;
+  }
+  h4 {
+    font-size: $font-md;
+  }
+  p {
+    font-size: $font-sm;
+    text-transform: none;
+    text-align: left;
+  }
+  a {
+    font-size: $font-sm;
+    white-space: nowrap;
+  }
+  .btn {
+    color: $navy;
+    background-color: $white;
+    border-width: 1px;
+    border-radius: 2px;
+    border-color: $navy;
+    width: fit-content;
+    height: auto;
+    &:hover {
+      background-color: $navy;
+      color: $white;
+    }
+  }
+}
+
+.catalyst-logo {
+  width: 8rem;
+  float: right;
+  @media screen and (max-width: 1170px) {
+    width: 6rem;
+  }
+  @media screen and (max-width: 768px) {
+    width: 8rem;
+  }
+}

--- a/themes/ansible-community/sass/main.scss
+++ b/themes/ansible-community/sass/main.scss
@@ -20,6 +20,7 @@
 @import "homepage-bullhorn-band";
 @import "homepage-events-band";
 @import "homepage-platform-band";
+@import "homepage-catalyst-band";
 @import "ecosystem";
 @import "mission-statement";
 @import "training";


### PR DESCRIPTION
Scenario guides no longer exist. They were removed in devel and will disappear from latest when Ansible 10 releases so changed a couple of links to point to the collection docs instead.

Also noticed a couple of controller links that should point to the controller docs on redhat.com now.

Lastly - there are a batch of links to Ansible.com at the bottom that won't exist when this website goes live. I haven't changed them here because I dunno if they have a new home somewhere on redhat.com or not.