### PR TITLE
change a pair of controller urls to access.redhat.com

### DIFF
--- a/pages/how-ansible-works.md
+++ b/pages/how-ansible-works.md
@@ -55,10 +55,10 @@ And if needed, Ansible can easily connect with Kerberos, Lightweight Directory A
 You can also just store usernames and passwords as variables for Ansible and encrypt them with [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html).
 This can be as easy as storing them in your inventory file, as elaborated on below.
 
-Red Hat Ansible Automation Platform [can act as a centralized authentication](https://docs.ansible.com/automation-controller/latest/html/userguide/credentials.html) as well as integrate with industry-standard tools like CyberArk AIM, Conjur, HashiCorp Vault, and Microsoft Azure Key Vault.
+Red Hat Ansible Automation Platform [can act as a centralized authentication](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/controller-credentials) as well as integrate with industry-standard tools like CyberArk AIM, Conjur, HashiCorp Vault, and Microsoft Azure Key Vault.
 Automation controller hashes local automation controller user passwords with the PBKDF2 algorithm using a SHA256 hash.
 Users who authenticate via external account mechanisms (LDAP, SAML, OAuth, and others) do not have any password or secret stored.
-For more information, check the [Secret handling and connection security](https://docs.ansible.com/automation-controller/latest/html/administration/secret_handling.html#ag-secret-handling) documentation.
+For more information, check the [Secret handling and connection security](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/automation_controller_administration_guide/controller-secret-handling-and-connection-security) documentation.
 
 # Manage your inventory in simple text files
 
@@ -68,7 +68,7 @@ To add new machines, there is no additional SSL signing server involved, so ther
 
 If there's another source of truth in your infrastructure, Ansible can also plug in to that, such as drawing inventory, group, and variable information from sources like Amazon Web Services, Google Compute Engine, Microsoft Azure, VMware vCenter, and more.
 Both community Ansible and Ansible Automation Platform can use a variety of [dynamic inventory plugins](https://docs.ansible.com/ansible/latest/plugins/inventory.html).
-Ansible Automation Platform makes these easily [available and configurable in the WebUI](https://docs.ansible.com/automation-controller/latest/html/userguide/inventories.html#inventory-plugins).
+Ansible Automation Platform makes these easily [available and configurable in the WebUI](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/controller-inventories#ref-controller-inventory-plugins).
 
 Here's what a plain text inventory file looks like:
 


### PR DESCRIPTION
Nearly all the controller guides are now up on access.redhat.com so changing a pair of them here to point to that insteand of docs.ansible.com versions of the controller guides