### PR TITLE
Keep python 3.11 as version in dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dockerfile"
-      - "dependencies"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the community website with Nikola
-FROM python:3.12 AS builder
+FROM python:3.11 AS builder
 
 # Add the contents of this repository to the working directory
 ADD . /community-website

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the community website with Nikola
-FROM python:3.13 AS builder
+FROM python:3.12 AS builder
 
 # Add the contents of this repository to the working directory
 ADD . /community-website


### PR DESCRIPTION
This PR reverts the dockerfile update that bumped the python version to 3.13. This seems to cause some problems with dependencies. I've also removed the docker updates from the dependabot config.

As a follow up, we should do some testing and update the python version in the requirements and other places so that everything is bumped at the same time.