### PR TITLE
ignore lets in spell checks

### DIFF
--- a/.codespellignorewords
+++ b/.codespellignorewords
@@ -1,1 +1,2 @@
 deque
+lets


### PR DESCRIPTION
Resolves codespell errors:

./data/ecosystem.yaml:66: lets ==> let's
./data/ecosystem.yaml:168: lets ==> let's
./data/ecosystem.yaml:258: lets ==> let's