### PR TITLE
remove the dev configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
   commands:
     - python -m pip install --upgrade --no-cache-dir pip setuptools
     - python -m pip install --upgrade -r ./requirements.in -c ./requirements.txt
-    - nikola build --conf=dev.conf.py
+    - nikola build
     - mkdir -p _readthedocs/html/
     - cp -r output/* _readthedocs/html/
     - rm _readthedocs/html/robots.txt

--- a/conf.py
+++ b/conf.py
@@ -20,7 +20,7 @@ BLOG_AUTHOR = "Ansible Community, et al"  # (translatable)
 BLOG_TITLE = "Ansible Community"  # (translatable)
 # This is the main URL for your site. It will be used
 # in a prominent link. Don't forget the protocol (http/https)!
-SITE_URL = "https://ansible.com/"
+SITE_URL = "https://ansible-community-website.readthedocs.io/"
 # This is the URL where Nikola's output will be deployed.
 # If not set, defaults to SITE_URL
 # BASE_URL = "https://ansible.community/"

--- a/dev.conf.py
+++ b/dev.conf.py
@@ -1,2 +1,0 @@
-from conf import *
-SITE_URL = "https://ansible-community-website.readthedocs.io/"


### PR DESCRIPTION
Related to https://github.com/ansible-community/community-website/pull/475

dev conf.py was useful for the RTD deployment so we could avoid having the site url be ansible.com