### PR TITLE
suppress elements that RTD injects

### DIFF
--- a/themes/ansible-community/sass/main.scss
+++ b/themes/ansible-community/sass/main.scss
@@ -66,10 +66,3 @@ h6 {
 #readthedocs-ea-text-nostyle-nodoctool {
     display: none !important;
 }
-
-readthedocs-notification,
-readthedocs-search,
-readthedocs-hotkeys,
-readthedocs-flyout {
-    display: none !important;
-}


### PR DESCRIPTION
Related to https://github.com/ansible-community/community-website/pull/475

RTD injects certain elements that cause issues with our styling such adding visible whitespace below the footer. these RTD elements are not necessary on the top-level landing pages. the flyout widget has no effect because the docsite is versionless and not built with sphinx so cross-project search won't work.