### PR TITLE
update the contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,61 +1,24 @@
-This is still a work in progress, and needs to be ratified.
-
-## Principles
+# Principles
 
 This repository adheres to the following principles:
 
 - Open: Contribution is always welcome.
 - Respectful: See the [Code of Conduct](CODE_OF_CONDUCT.md).
 - Transparent and accessible: Work and collaboration should be done in public.
-  See [Governance](#governance) section for details.
 - Merit: Ideas and contributions are accepted according to their merit and
   alignment with the project objectives principles.
 
 ## How to contribute
 
 We are very happy to receive contributions from the community in any form, but in particular we would love:
-- Blog posts
+
 - New resources
 - Typos / fixes
 - Style improvements
 
 Please use a GitHub pull request to submit your contributions. If you have a
 question or are unsure if a contribution is wanted, please join us in
-[TBD](#channel-name-here) on Matrix  or (IRC name here) to discuss your change. If
-you prefer async discussion, feel free to open a GitHub issue with your
-question/suggestion.
-
-## Governance
-
-The Ansible Community website is the landing page for all Ansible users and
-contributors. It represents the first thing a new user will see, a signposting
-resource for returning learners, and a content source for those who want to
-know more. As such, it is important that the website be maintained with care.
-
-The Website Working Group is tasked with this responsibility, and it uses the
-following governance (using keywords as defined in [RFC
-2119](https://www.rfc-editor.org/rfc/rfc2119)
-
----
-- The Website Working Group (WWG) SHALL manage the Ansible Community website.
-- The WWG SHALL ensure their own succession over time by promoting the most
-  effective Contributors.
-- The WWG SHOULD remove Members who are inactive for an extended period of
-  time, or who repeatedly fail to apply this process accurately.
----
-- A patch SHOULD have a minimum of 2 reviews from Members before it is merged.
-- Members SHOULD NOT review/merge their own patches except in exceptional
-  cases.
-- Written content SHOULD be checked for accuracy at the time of writing.
-- Visual changes SHOULD be deployed to a test site to ensure the change works
-  as intended.
----
-- All Contributions MUST be done using the GitHub PR process.
-- Any Contributor MAY submit any patches they feel are suitable for inclusion.
-- Any Contributor MAY review the patches of other Contributors. 
-- Any Contributor who makes correct patches, writes good reviews, who clearly
-  understands the project goals, and the process SHOULD be invited to become a
-  Member of the WWG.
----
-
-(inspired by the [C4 process](https://rfc.zeromq.org/spec/42))
+[Ansible Docs](https://matrix.to/#/#docs:ansible.com) on Matrix to discuss your change. If
+you prefer async discussion, feel free to start a new
+[discussion topic](https://forum.ansible.com/c/project/7)
+on the Ansible forum or open a GitHub issue with your question/suggestion.


### PR DESCRIPTION
Related to https://github.com/ansible-community/community-website/pull/475

make the contributing guide more relevant for the docsite instead of the community website