### PR TITLE
Add Red Hat Campaign IDs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -152,15 +152,15 @@ NAVIGATION_ALT_LINKS = {
     DEFAULT_LANG: (
         (
           (
-            ("https://docs.ansible.com/ansible/latest/index.html", "Ansible package documentation", ""),
+            ("https://docs.ansible.com/projects/ansible/latest/index.html", "Ansible package documentation", ""),
             ("/users.html", "Users", ""),
             ("/developers.html", "Developers", ""),
             ("/maintainers.html", "Maintainers", ""),
             ("/ecosystem.html", "Ecosystem", ""),
-            ("https://docs.ansible.com/ansible/latest/collections/index.html", "Collection index", ""),
-            ("https://docs.ansible.com/ansible/latest/collections/all_plugins.html", "Modules and plugins index", ""),
+            ("https://docs.ansible.com/projects/ansible/latest/collections/index.html", "Collection index", ""),
+            ("https://docs.ansible.com/projects/ansible/latest/collections/all_plugins.html", "Modules and plugins index", ""),
             ("/ansible-prior-versions.html", "Documentation archive", ""),
-            ("https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/", "Red Hat Ansible Automation Platform", ""),
+            ("https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/?sc_id=RHCTE0250000464439", "Red Hat Ansible Automation Platform", ""),
           ),
           "Resources", ""
         ),

--- a/data/homepage.yaml
+++ b/data/homepage.yaml
@@ -28,13 +28,13 @@ ansible:
 links:
   get_started:
     label: Get started with Ansible
-    url: https://docs.ansible.com/ansible/latest/getting_started/index.html
+    url: https://docs.ansible.com/projects/ansible/latest/getting_started/index.html
   platform:
     label: Red Hat Ansible Automation Platform
-    url: https://www.redhat.com/en/technologies/management/ansible
+    url: https://www.redhat.com/en/technologies/management/ansible?sc_id=RHCTE0250000464439
   platform_docs:
     label: Red Hat Ansible Automation Platform documentation
-    url: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/
+    url: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/?sc_id=RHCTE0250000464439
 tab_menu:
   get_started: Get started
   users: Users

--- a/themes/ansible-community/templates/base_footer.tmpl
+++ b/themes/ansible-community/templates/base_footer.tmpl
@@ -9,7 +9,8 @@
                target="_blank">CC BY-SA 4.0</a>
           </li>
           <li>
-            <a href="https://www.redhat.com/en/about/privacy-policy?sc_id=RHCTE0250000464439" target="_blank">Privacy policy</a>
+            <a href="https://www.redhat.com/en/about/privacy-policy?sc_id=RHCTE0250000464439"
+               target="_blank">Privacy policy</a>
           </li>
           <li>
             <a href="https://docs.ansible.com/ansible/latest/community/code_of_conduct.html"

--- a/themes/ansible-community/templates/base_footer.tmpl
+++ b/themes/ansible-community/templates/base_footer.tmpl
@@ -9,7 +9,7 @@
                target="_blank">CC BY-SA 4.0</a>
           </li>
           <li>
-            <a href="https://www.redhat.com/en/about/privacy-policy" target="_blank">Privacy policy</a>
+            <a href="https://www.redhat.com/en/about/privacy-policy?sc_id=RHCTE0250000464439" target="_blank">Privacy policy</a>
           </li>
           <li>
             <a href="https://docs.ansible.com/ansible/latest/community/code_of_conduct.html"

--- a/themes/ansible-community/templates/base_footer.tmpl
+++ b/themes/ansible-community/templates/base_footer.tmpl
@@ -9,8 +9,7 @@
                target="_blank">CC BY-SA 4.0</a>
           </li>
           <li>
-            <a href="https://www.redhat.com/en/about/privacy-policy?sc_id=RHCTE0250000464439"
-               target="_blank">Privacy policy</a>
+            <a href="https://www.redhat.com/en/about/privacy-policy" target="_blank">Privacy policy</a>
           </li>
           <li>
             <a href="https://docs.ansible.com/ansible/latest/community/code_of_conduct.html"


### PR DESCRIPTION
Add Campaign IDs, and use the new Read The Docs URLs (to avoid a redirect)