### PR TITLE
fix(theme): format post template

### DIFF
--- a/themes/ansible-community/templates/post.tmpl
+++ b/themes/ansible-community/templates/post.tmpl
@@ -24,7 +24,9 @@
           title="{{ post.next_post.title() |e }}"
           type="text/html">
   {% endif %}
-  {% if post.is_draft %}<meta name="robots" content="noindex">{% endif %}
+  {% if post.is_draft %}
+    <meta name="robots" content="noindex">
+  {% endif %}
   {{ helper.open_graph_metadata(post) }}
   {{ helper.twitter_card_information(post) }}
   {{ helper.meta_translations(post) }}


### PR DESCRIPTION
1. c6eb393 (Dec 2023) added the single-line {% if post.is_draft %}...{% endif %} to post.tmpl. At that time, djlint --reformat would reformat the file but exit 0, so CI passed — it silently reformatted without failing.
2. A recent djlint release (installed unpinned via session.install("djlint")) changed --reformat to exit 1 when it makes any changes. This is the behavior you see locally — "Command djlint - --reformat failed with exit code 1".
3. The format nox session was never really a CI gate — it ran the formatter but couldn't detect drift because the old djlint always exited 0. The recent djlint release effectively turned it into a proper format check.

So the formatting issue has existed since Dec 2023 but was invisible because djlint didn't fail on reformatted files until recently. The dependabot PR just happened to be the first CI run after the new djlint version landed on PyPI.