### PR TITLE
Document journeys

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,18 @@ Ask these questions when deciding where content fits in the journey:
 - "Can the persona complete the action with this content alone, or are there missing steps?"
 - "Does adding this content reveal any gaps in the surrounding milestone?"
 
+Keep these constraints in mind:
+
+- Milestones are sequential.
+  Each milestone builds on the previous one, so do not place advanced actions in early milestones or reorder milestones.
+- Do not duplicate actions across milestones.
+  Each action should appear once, in the milestone where it is most relevant.
+- Keep content within its persona.
+  Do not add developer-oriented actions to the user journey or vice versa.
+- Do not remove or rename milestone keys without checking the corresponding template, as it may reference the key directly.
+- Each action should link to a single, focused documentation page that serves as an entry point for that action.
+  Avoid linking to broad index pages.
+
 ### Milestone structure
 
 The `data/*.yaml` files for personas have the following structure:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,125 @@ We are very happy to receive contributions from the community in any form, but i
 - Typos / fixes
 - Style improvements
 
-Please use a GitHub pull request to submit your contributions. If you have a
-question or are unsure if a contribution is wanted, please join us in
-[Ansible Docs](https://matrix.to/#/#docs:ansible.com) on Matrix to discuss your change. If
-you prefer async discussion, feel free to start a new
-[discussion topic](https://forum.ansible.com/c/project/7)
-on the Ansible forum or open a GitHub issue with your question/suggestion.
+Please use a GitHub pull request to submit your contributions.
+If you have a question or are unsure if a contribution is wanted, please join us in [Ansible Docs](https://matrix.to/#/#docs:ansible.com) on Matrix to discuss your change.
+If you prefer async discussion, feel free to start a new [discussion topic](https://forum.ansible.com/c/project/7) on the Ansible forum or open a GitHub issue with your question/suggestion.
+
+## Journey-based design
+
+This project has a specific design that helps various personas in the Ansible community achieve their goals.
+Contributions that add or modify the pages, templates, or data related to a specific persona, such as `users`, `developers`, `maintainers`, or `community`, should consider this design.
+
+### Personas and journeys
+
+You can consider a persona as a type of human role.
+A persona describes the focus and general goals for someone in the Ansible community as well as the needs, attitude, and knowledge that a human in that role would have.
+
+Each persona has milestones towards achieving their goals.
+Each milestone has specific major actions that the persona must complete to make progress.
+These milestones and major actions outline the journeys for each persona, for example:
+
+```yaml
+Milestone: Aware
+  Learn about Ansible
+Milestone: Evaluate
+  Install Ansible
+  Run some basic ad-hoc commands
+Milestone: Adopt
+  Build an inventory
+  Create playbooks
+Milestone: Scale
+  Build execution environments
+  Schedule automation jobs in AWX
+```
+
+- Ansible community personas are defined in [`data/journeys/personas.md`](https://github.com/ansible-community/ansible-docsite/blob/main/data/journeys/personas.md).
+- Journeys are defined in [`data/journeys/journeys.md`](https://github.com/ansible-community/ansible-docsite/blob/main/data/journeys/journeys.md).
+
+### How it works
+
+The `pages/*.md` files define each page with frontmatter that maps a URL to a template.
+The `templates/*.tmpl` templates contain the structure for the various homepage bands and subpages.
+The `data/*.yaml` files contain the labels and links that appear on the generated pages.
+
+The site is built with [Nikola](https://getnikola.com/), which uses `load_data()` in `conf.py` to make the YAML data available to the templates.
+You do not need to modify `conf.py` to add or update content in existing data files.
+
+#### Homepage bands for personas
+
+Homepage bands are the horizontal sections at the root of `docs.ansible.com`.
+Each persona has a dedicated band that provides entry points to their journeys.
+
+For example, [`templates/homepage-users-band.tmpl`](https://github.com/ansible-community/ansible-docsite/blob/7d3c98f192eb04a9485c3a5e7901baa2e65c6714/templates/homepage-users-band.tmpl#L14) takes the key-value pairs defined for the user persona in [`data/homepage.yaml`](https://github.com/ansible-community/ansible-docsite/blob/7d3c98f192eb04a9485c3a5e7901baa2e65c6714/data/homepage.yaml#L58).
+
+The homepage bands are intended to provide "quick wins" for personas.
+Those links should not be changed in most cases because they are the most essential actions in the primary milestone for each persona.
+
+It would not make sense, for instance, to link an action on the homepage band if it relates to an action that a given persona would complete during a much later milestone.
+
+#### Persona journey pages
+
+Each persona has a journey page that is linked from the homepage.
+The journey pages outline all the milestones and actions for each persona.
+
+For example, [`templates/users.tmpl`](https://github.com/ansible-community/ansible-docsite/blob/7d3c98f192eb04a9485c3a5e7901baa2e65c6714/templates/users.tmpl#L25) takes the key-value pairs for milestones defined in [`data/users.yaml`](https://github.com/ansible-community/ansible-docsite/blob/7d3c98f192eb04a9485c3a5e7901baa2e65c6714/data/users.yaml#L2).
+
+This avoids the need to modify the template to add new labels and links.
+More importantly, this design allows you to focus on specific journeys to better understand the needs of the persona and more effectively put a documentation link where the user expects to find it.
+
+"If you are at milestone _foo_, then you need to complete task _bar_ before you can continue to the next milestone."
+
+### Placing content in a journey
+
+When adding or modifying content in this project, you should follow this journey-based design at all times.
+For example, if you plan to add a link to a documentation page in `data/users.yaml`, you should consider where that page fits in the journey for the user persona.
+Do not add links arbitrarily or based on visual layout alone.
+
+Considering the user journey from the outset, when planning content, is a powerful way to take the user's perspective.
+By thinking about what the persona needs at each milestone, you can identify gaps and deliver more complete content.
+
+Ask these questions when deciding where content fits in the journey:
+
+- "Which persona does this content serve?"
+- "What milestone is the persona at when they need this content?"
+- "Is this an essential action for that milestone, or does it belong in a later one?"
+- "Does this content provide a high-level entry point for the action?"
+- "Can the persona complete the action with this content alone, or are there missing steps?"
+- "Does adding this content reveal any gaps in the surrounding milestone?"
+
+### Milestone structure
+
+The `data/*.yaml` files for personas have the following structure:
+
+```yaml
+milestones: # Root key for journeys
+  automate: # Key that defines a milestone in the journey
+    title: # Title for the milestone using imperative
+    actions: # Root key for major actions
+      start: # Key that defines a major action in the milestone
+        label: # Label for the major action
+        url: # Link to the corresponding documentation page
+```
+
+There can be any number of milestones in the journey.
+
+A milestone must contain at least one action.
+However, it is ideal for milestones to contain between three and five actions.
+
+The `title` and `label` keys must always use the imperative form, for example:
+
+```yaml
+title: Create automation
+label: Start writing Ansible playbooks
+```
+
+## Updating the quicklinks
+
+Each of the persona pages includes a _quicklinks_ section.
+
+For example, [`templates/users.tmpl`](https://github.com/ansible-community/ansible-docsite/blob/7d3c98f192eb04a9485c3a5e7901baa2e65c6714/templates/users.tmpl#L10) uses the quicklinks for users defined in [`data/quicklinks.yaml`](https://github.com/ansible-community/ansible-docsite/blob/7d3c98f192eb04a9485c3a5e7901baa2e65c6714/data/quicklinks.yaml#L18).
+
+These quicklinks are intended to provide easy access to the top pages for each persona.
+The quicklinks are determined by looking at anonymous traffic results to see which pages are most frequently searched for or accessed.
+
+Never add an entry to the quicklinks section to promote or highlight pages.

--- a/data/journeys/journeys.md
+++ b/data/journeys/journeys.md
@@ -2,71 +2,106 @@
 
 This document extends Ansible community personas by identifying and describing their journeys.
 
-[Ansible community personas](personas.md)
-
-## Intro
-
-Each persona has specific milestones in their respective journey.
-And each milestone has specific major actions that the persona achieves.
-The first milestone of each journey starts with human motivation.
-
-```yaml
-Milestone: Aware
-  Major action
-  Major action
-  ...
-Milestone: Evaluate
-  Major action
-  Major action
-  ...
-Milestone: Adopt
-  Major action
-  Major action
-  ...
-Milestone: Scale
-  Major action
-  Major action
-  ...
-```
-
 ## Novice
 
+The novice journey is the basis for the "Get started with Ansible" section on the docsite index page.
+
 ```yaml
-Milestone: Learn about Ansible
-  Read a brief description of what Ansible is
-  Redirect to the docs for onward learning journey, if needed
-Milestone: Install Ansible
-  Learn how to install via pip
-  Find out if OS-level packages exist for a system
-Milestone: Get started with simple executions
-  Redirect to the docs for onward quick-start journey
-Milestone: Ask a question
-  Understand what mediums are available
-  Choose a preferred medium, and redirect appropriately
-  Ask the question
+Milestone: Need to learn the basics
+  Understand the challenges of modern infrastructure management [content gap]
+  Understand the fundamentals of Ansible automation
+
+Milestone: Set up an automation project
+  Install the Ansible package
+  Run your first ad hoc command in a few easy steps
 ```
 
-## Contributor
+## Users
 
 ```yaml
-Milestone: Learn how to contribute
-  Understand how open source contribution works
-  Understand the types of contribution that are possible
-  Be aware of the Code of Conduct
-Milestone: Support the wider project
-  Understand how to help with events / forum / chat
-  Understand what community meetings are regularly held
-  Redirect to the right place to participate
-Milestone: Find a sub project / working group to participate in
-  Understand what groups exist and where to find them
-  Redirect to the repo / forum group / chatroom to participate
+Milestone: Create automation
+  Start writing Ansible playbooks
+  Learn about Ansible modules
+
+Milestone: Learn inventories
+  Build inventory files to manage multiple hosts
+  Use dynamic inventories
+
+Milestone: Organize automation projects
+  Use roles to structure the automation project
+
+Milestone: Use Ansible tooling
+  Use Ansible Lint to validate playbooks
+  Install Molecule to develop and test Ansible roles
+  Create and test playbooks with Ansible Navigator
+  Use Ansible with Visual Studio Code and OpenVSX compatible editors
+
+Milestone: Find Automation content
+  Start exploring Ansible Galaxy
+  Install and use roles
+  Install and use collections
+
+Milestone: Share automation content
+  Submit roles to an existing collection
+  Create a new collection
+  Upload a collection to Ansible Galaxy
+
+Milestone: Schedule and run automation jobs [TODO Add AWX overview, API]
+  Execute automation jobs on demand
+  Schedule automation jobs
+
+Milestone: Embed automation in systems
+  Build execution environment with specific dependencies
+  Use execution environments with AWX jobs
 ```
 
-## Customer
+## Developers
 
 ```yaml
-Milestone: Learn about the products
-  Understand that this is the upstream project which powers the products
-  Understand that customers are welcome in the community
-  Redirect to the product site
+Milestone: Start writing code
+  Set up your development environment
+  Learn how Ansible works
+  Write custom modules or plugins
+
+Milestone: Contribute code to a collection
+  Make your first contribution
+  Explore Collection contributor guide
+  Contribute your module to an existing collection
+  Review the lifecycle of an Ansible module or plugin
+
+Milestone: Test plugins and modules
+  Understand testing in Ansible
+  Run sanity tests
+  Write integration tests
+  Write unit tests
+
+Milestone: Create new collections
+  Set things up with the collection skeleton
+  Test your collection for code quality
+  Publish your collection on a distribution server
+  Request a collection be added to the Ansible package
+```
+
+## Maintainers
+
+```yaml
+Milestone: Learn about community maintainer responsibilities
+  Review community maintainer responsibilities
+  Backport merged pull requests to stable branches
+  Regularly release stable versions
+  Look after collection documentation
+
+Milestone: Expand community around a collection
+  Explore ways to grow community
+  Maintain good contributor documentation
+  Understand Ansible contributor paths
+
+Milestone: Get collections included in the Ansible package
+  Understand the inclusion process
+  Review other inclusion requests
+  Submit your collection for inclusion
+
+Milestone: Participate in cross-project governance
+  Discuss and vote on community topics
+  Join the Ansible community steering committee
 ```

--- a/data/journeys/personas.md
+++ b/data/journeys/personas.md
@@ -1,39 +1,60 @@
 # Ansible community personas
 
-Personas represent various humans who are all on different journeys within the Ansible community. These personas help put community users, or members, in context to identify what content they need at each stage of their respective journeys.
+Personas represent various humans who are all on different automation journeys with Ansible.
+These personas help put users in context to identify their technical content needs at each stage of their respective journeys.
 
-We use personas to ensure Ansible community users can find help when and where they need it. If the right support is there, users are much more likely to succeed with their goals. This leads to higher levels of adoption and a more vibrant, stronger community.
+We use personas to ensure Ansible community users can find help when and where they need it.
+If the right support is there, users are much more likely to succeed with their goals.
+This leads to higher levels of adoption and a more vibrant, stronger community.
 
-The practical goal of defining these personas is to improve the navigation and layout of the Ansible community website.
-
-We use single words for the persona names, so that they are easy to refer to in code/documentation/etc internally. Explanations of the words are given underneath.
+The practical goal of defining these personas is to improve the navigation and layout of the `docs.ansible.com` landing pages.
 
 ## Novice
 
-The word novice is not implied to mean someone unskilled, but rather someone new to Ansible who is looking for general information.
+<img src="https://i.imgur.com/GMilRTB.png" alt="Person using a computer" width="100"/>
 
-I'm a general technologist who's interested in automation, or has heard about Ansible in some way. I've landed here after a search and want guidance to my next steps.
+I'm a general technologist who has an idea about automation. I might already have a project or solution in mind and want to see if Ansible is the right tool for the job.
 
-* **Needs:** Clear information about where they have landed. Clear direction to next steps (docs, forum, chat, install method)
-* **Attitude:** Curious, in learning mode. Will tolerate having to hunt a little, but *only* a little.
-* **Knowledge:** Generally capable with tech, familiar with other project sites. Expects similar layout/navigation to get what they need.
+* **Needs:** A low barrier of entry to gain the fundamentals of Ansible automation.
+* **Attitude:** Wants to understand basic concepts quickly and can find small obstacles frustrating.
+* **Knowledge:** Undetermined. It is possible that I use Microsoft Windows as my primary operating system. I might even be completely new to open-source technology. I can be a Linux enthusiast doing home automation, a member of an IT team for a small business, or a solution architect for large enterprise.
 
-## Contributor
+## User
 
-Here contributor also includes *potential* contributors - in any case, people looking to get more deeply involved with the project
+<img src="https://i.imgur.com/VrX4ygq.png" alt="Person using a computer" width="100"/>
 
-I'm already an Ansible user and I'm looking to connect with the project, or I'm already part of the Ansible community and looking to participate in a new area.
+I write automation content like playbooks and roles. When writing playbooks and roles I like to evaluate multiple options to find simple solutions to complex problems.
 
-* **Needs:** Information on what places exist for connection/participation (bullhorn, forum, chat rooms, upcoming meetings & events)
-* **Attitude:** Excited / enthusiastic. Wants to contribute, but may back down if there are blockers or lack of information
-* **Knowledge:** Understands Ansible, *may* understand open source contribution in general. In the case of existing members, probably knows the project structure somewhat, but not the specifics of where to find people on another sub-project.
+* **Needs:** Needs best practice information that is up to date and complete.
+* **Attitude:** Does not like out of date, incomplete, or missing documentation.
+* **Knowledge:** Proficient. I am at home on the command line and enjoy technical challenges.
 
-## Customer
+## Developer
 
-Here we are talking about "Enterprise decision makers". With the name "Ansible" being overloaded, there is high chance that a user will end up on the community site even though they are looking for product information. In addition, we should be clear about our relationship with Red Hat as our primary sponsor - these can be combined together.
+<img src="https://i.imgur.com/QufXcjw.png" alt="Person using a computer" width="100"/>
 
-I'm looking for information on Red Hat's Ansible offerings. I might be an exiting customer looking for specific detail, or a new customer looking to learn more about the product line
+I write, or want to start writing, Ansible plugins and modules in Python or other programming languages. I might also want to write code for Ansible projects such as Lint, Molecule, or Event-driven Ansible.
 
-* **Needs:** Clear direction to the product pages, one click away.
-* **Attitude:** Possibly irritated that they didn't land on the product right away. Might appreciate being aware of the upstream community, but wants to get to their target.
-* **Knowledge:** Unclear, but business-focussed for sure. Might be aware of RHAAP, AutomationHub, etc, or might be a community user of Ansible looking to go further
+* **Needs:** Understand programmatic options and their expected behaviour.
+* **Attitude:** Technically curious and prefers verbosity.
+* **Knowledge:** Basic to expert level programming ability.
+
+## Community maintainer
+
+<img src="https://i.imgur.com/GY18SFy.png" alt="Person using a computer" width="100"/>
+
+I work with the community to maintain one or more collections as part of the Ansible package. Alternatively I might want to create my own collection and set everything up so I can run and maintain my collection. I might also be interested in working on community tooling such as Antsibull or other projects.
+
+* **Needs:** Clear path for creating collections from scratch and optionally getting them included in the Ansible package. Guidance on lifecycles and maintenance guidelines.
+* **Attitude:** Often busy with another more primary role.
+* **Knowledge:** Basic to expert IT skills with project management.
+
+## Community member/evangelist
+
+<img src="https://imgur.com/aseD8ux.png" alt="Kitten at a keyboard" width="120"/>
+
+I participate in the Ansible ecosystem community to learn and share my Ansible knowledge.
+
+* **Needs:** Guidance on where and how I can contribute as a non-coder for Ansible projects.
+* **Attitude:** Enthusiastic about Ansible.
+* **Knowledge:** Intermediate or above expertise in one or more parts of Ansible.

--- a/data/journeys/personas.md
+++ b/data/journeys/personas.md
@@ -35,7 +35,7 @@ I write automation content like playbooks and roles. When writing playbooks and 
 
 I write, or want to start writing, Ansible plugins and modules in Python or other programming languages. I might also want to write code for Ansible projects such as Lint, Molecule, or Event-driven Ansible.
 
-* **Needs:** Understand programmatic options and their expected behaviour.
+* **Needs:** Understand programmatic options and their expected behavior.
 * **Attitude:** Technically curious and prefers verbosity.
 * **Knowledge:** Basic to expert level programming ability.
 


### PR DESCRIPTION
This change explains the journey based design for project contributors.

This pull request also ports over the journeys and personas that were included in the https://github.com/ansible/docsite repo. I should have done that when I refactored this project from the community website to reuse it for the docsite landing pages.